### PR TITLE
Add Adapter aliases or rename from menu

### DIFF
--- a/installer/common.sh
+++ b/installer/common.sh
@@ -379,7 +379,7 @@ get_pi_info() {
 }
 
 convert_template() {
-    /etc/ConsolePi/j2render.py "$@"
+    /etc/ConsolePi/src/j2render.py "$@"
     file_diff_update /tmp/${1} $2
     rm /tmp/${1} >/dev/null 2>>$log_file
 }

--- a/installer/install2.sh
+++ b/installer/install2.sh
@@ -332,9 +332,9 @@ verify() {
 }
 
 chg_password() {
-    if [[ $iam == "pi" ]]; then 
+    if [[ $iam == "pi" ]] && [ -e /run/sshwarn ]; then 
         header
-        echo "You are logged in as pi, the default user."
+        echo "You are logged in as pi, and the default password for the 'pi' user has not been changed"
         prompt="Do You want to change the password for user pi"
         response=$(user_input_bool)
         if $response; then

--- a/src/10-ConsolePi.rules
+++ b/src/10-ConsolePi.rules
@@ -1,0 +1,41 @@
+# Created by ConsolePi ~ Pack3tL0ss
+#   -- It's OK to edit manually, however keep manual edits to add/del device lines 
+#   -- Comments and LABELs should remain as changing them may break ConsolePis
+#   -- ability to automate the addition of adapters properly
+
+# ---------------- // COLLECT AND STORE ATTRIBUTES FROM VARIOUS LEVELS OF DEV HIERARCHY \\ --------------------------------
+SUBSYSTEM!="tty", GOTO="serial_end"
+SUBSYSTEMS=="usb", IMPORT{builtin}="usb_id", IMPORT{builtin}="hwdb --subsystem=usb"
+KERNEL!="ttyUSB[0-9]*|ttyACM[0-9]*", GOTO="END"
+SUBSYSTEMS=="usb-serial", ENV{.ID_PORT}="$attr{port_number}"
+ENV{ID_SERIAL}=="", GOTO="BYPATH-DEVS"
+SUBSYSTEMS=="usb", ENV{ID_USB_INTERFACE_NUM}="$attr{bInterfaceNumber}"
+# ENV{ID_USB_INTERFACE_NUM}=="", GOTO="END"
+
+# -------------- // ByPort Multi-Port Adapter w/ Single Serial# for All Ports GOTO --> BYPORT-DEVS \\ -----------------------
+# Multi-Port Pigtail adapters that present the same serial for all ports but have unique USB IF#.
+# BYPORT-POINTERS
+# END BYPORT-POINTERS
+
+# ---------------------- // ByPath devs That Lack Serial# GOTO --> BYPORT-DEVS \\ --------------------------------------------
+# -- Devices Lacking a serial #.  Mapped to specific USB port, any device plugged into that port will use this alias.
+# -- This is only useful if the adapters stay static.  These adapters are super Lame.
+# -- Check w/ vendor/chipset online to see if there is a method to re-flash the adapter with a serial.
+# BYPATH-POINTERS
+# END BYPATH-POINTERS
+
+# ------------- // BySerial-devs Each has a Unique Serail# (The Gold Std) Define then GOTO --> END \\ ------------------------
+# BYSERIAL-DEVS
+# END BYSERIAL-DEVS
+SUBSYSTEM=="tty", GOTO="END"
+
+# ------------- // ByPort-devs Single Serial for multi-port with unique port IDs Define then GOTO --> END \\ -----------------
+# BYPORT-DEVS
+# END BYPORT-DEVS
+SUBSYSTEM=="tty", GOTO="END"
+
+# ---------------------- // ByPath-devs alias is mapped to the USB port not the specific adapter \\ ---------------------------
+LABEL="BYPATH-DEVS"
+# END BYPATH-DEVS
+
+LABEL="END"

--- a/src/PyConsolePi/common.py
+++ b/src/PyConsolePi/common.py
@@ -346,7 +346,7 @@ class ConsolePi_data(Outlets):
                                     # -- fail_cnt persistence so Unreachable ConsolePi learned from Gdrive sync can still be flushed
                                     # -- after 3 failed connection attempts.
                                     if 'fail_cnt' not in remote_consoles[_] and 'fail_cnt' in current_remotes[_]:
-                                        remote_consoles[_]['fail_cnt'] = {self.hostname: current_remotes[_]['fail_cnt']}
+                                        remote_consoles[_]['fail_cnt'] = current_remotes[_]['fail_cnt']
                                     log.info('[CACHE UPD] {} Updating data from {} based on more current update time'.format(_, remote_consoles[_]['source']))
                             elif 'upd_time' in current_remotes[_]:
                                     remote_consoles[_] = current_remotes[_] 

--- a/src/PyConsolePi/common.py
+++ b/src/PyConsolePi/common.py
@@ -614,3 +614,35 @@ def kill_hung_session(dev):
                 ppid = find_procs_by_name('picocom', dev)
             retry += 1
     return ppid is None
+
+def get_attached_adapters():
+    """Detect Locally Attached Adapters.
+    
+    Returns
+    -------
+    dict
+        udev alias/symlink if defined/found as key or root device if not. 
+        /dev/ is stripped: (ttyUSB0 | AP515).  Each device has it's attrs
+        in a dict.
+    """
+    context = pyudev.Context()
+
+    devs = {}
+    for _dev in context.list_devices(subsystem='tty', ID_BUS='usb'):
+        for alias in _dev['DEVLINKS'].split():
+            if '/dev/serial/by-' not in alias:
+                dev_name = alias.strip('/dev/')
+                break
+            else:
+                dev_name = _dev['DEVNAME'].strip('/dev/')
+        devs[dev_name] = \
+                {
+                    'id_prod': _dev.get('ID_MODEL'),
+                    'id_serial': _dev.get('ID_SERIAL_SHORT'),
+                    'id_ifnum': _dev.get('ID_USB_INTERFACE_NUM'),
+                    'id_vendor': _dev.get('ID_VENDOR_ID'),
+                    'id_path': _dev.get('ID_PATH')
+                }
+
+    return devs
+

--- a/src/PyConsolePi/common.py
+++ b/src/PyConsolePi/common.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pyudev
 import psutil
 from sys import stdin
+import serial
 from .power import Outlets
 
 # Common Static Global Variables
@@ -61,6 +62,29 @@ class ConsolePi_data(Outlets):
 
     def __init__(self, log_file=CLOUD_LOG_FILE, do_print=True):
         super().__init__(POWER_FILE)
+
+        # init ConsolePi.conf values
+        self.cfg_file_ver = None
+        self.push = None
+        self.push_all = None
+        self.push_api_key = None
+        self.push_iden = None
+        self.ovpn_enable = None
+        self.vpn_check_ip = None
+        self.net_check_ip = None
+        self.local_domain = None
+        self.wlan_ip = None
+        self.wlan_ssid = None
+        self.wlan_psk = None
+        self.wlan_country = None
+        self.cloud = None
+        self.cloud_svc = None
+        self.power = None
+        self.tftpd = None
+        self.debug = None
+
+        # build attributes from ConsolePi.conf values
+        # and GLOBAL variables
         config = self.get_config_all()
         for key, value in config.items():
             if type(value) == str:
@@ -78,6 +102,7 @@ class ConsolePi_data(Outlets):
                 for _ in value:
                     x.append(_)
                 exec('self.{} = {}'.format(key, x))
+
         self.do_print = do_print
         self.log_file = log_file
         cpi_log = ConsolePi_Log(log_file=log_file, do_print=do_print, debug=self.debug) # pylint: disable=maybe-no-member
@@ -100,8 +125,8 @@ class ConsolePi_data(Outlets):
         self.remotes = self.get_local_cloud_file()
         if stdin.isatty():
             self.rows, self.cols = self.get_tty_size()
-        self.display_con_settings = False
         self.root = True if os.geteuid() == 0 else False
+        self.new_adapters = detect_adapters()
 
     def get_tty_size(self):
         size = subprocess.run(['stty', 'size'], stdout=subprocess.PIPE)
@@ -145,6 +170,7 @@ class ConsolePi_data(Outlets):
         ret_data = locals()
         for key in ['self', 'config', 'line', 'var', 'value']:
             ret_data.pop(key)
+
         return ret_data
 
     # TODO run get_local in blocking thread abort additional calls if thread already running
@@ -176,6 +202,7 @@ class ConsolePi_data(Outlets):
         for tty_dev in final_tty_list:
             tty_port = 9999 # using 9999 as an indicator there was no def for the device.
             flow = 'n' # default if no value found in file
+            # serial_list.append({tty_dev: {'port': tty_port}}) # PLACEHOLDER FOR REFACTOR with dev name as key
             # -- extract defined TELNET port and connection parameters from ser2net.conf --
             if os.path.isfile('/etc/ser2net.conf'):
                 with open('/etc/ser2net.conf', 'r') as cfg:
@@ -215,13 +242,14 @@ class ConsolePi_data(Outlets):
                 msg = '[GET ADAPTERS] No ser2net.conf file found unable to extract port definition'
                 log.error(msg)
                 self.error_msgs.append(msg)
-                self.display_con_settings = True
+                serial_list.append({'dev': tty_dev, 'port': tty_port})
 
             if tty_port == 9999:
-                msg = '[GET ADAPTERS] No ser2net.conf definition found for {}'.format(tty_dev)
+                msg = '[GET ADAPTERS] No ser2net.conf definition found for {}'.format(tty_dev.strip('/dev/'))
                 log.error(msg)
                 self.error_msgs.append(msg)
-                self.display_con_settings = True
+                self.error_msgs.append('Use option \'c\' to change connection settings for ' + tty_dev.strip('/dev/'))
+                serial_list.append({'dev': tty_dev, 'port': tty_port})
             else:
                 serial_list.append({'dev': tty_dev, 'port': tty_port, 'baud': baud, 'dbits': dbits,
                         'parity': parity, 'flow': flow})
@@ -490,7 +518,7 @@ def error_handler(cmd, stderr):
         else:
             return 'User Abort or Failure to kill existing session to {}'.format(cmd[1].replace('/dev/', ''))
 
-def bash_command(cmd, do_print=False):
+def bash_command(cmd, do_print=False, eval_errors=True):
     # subprocess.run(['/bin/bash', '-c', cmd])
     response = subprocess.run(['/bin/bash', '-c', cmd], stderr=subprocess.PIPE)
     _stderr = response.stderr.decode('UTF-8')
@@ -498,8 +526,9 @@ def bash_command(cmd, do_print=False):
         print(_stderr)
     # print(response)
     # if response.returncode != 0:
-    if _stderr:
-        return error_handler(getattr(response, 'args'), _stderr)
+    if eval_errors:
+        if _stderr:
+            return error_handler(getattr(response, 'args'), _stderr)
 
 def is_valid_ipv4_address(address):
     try:
@@ -615,7 +644,7 @@ def kill_hung_session(dev):
             retry += 1
     return ppid is None
 
-def detect_adapters():
+def detect_adapters(key=None):
     """Detect Locally Attached Adapters.
 
     Returns
@@ -627,22 +656,73 @@ def detect_adapters():
     """
     context = pyudev.Context()
 
-    devs = {}
+    devs = {'by_name': {}, 'dup_ser': {}}
     for _dev in context.list_devices(subsystem='tty', ID_BUS='usb'):
+        root_dev = _dev['DEVNAME'].strip('/dev/')
         for alias in _dev['DEVLINKS'].split():
             if '/dev/serial/by-' not in alias:
                 dev_name = alias.strip('/dev/')
                 break
             else:
-                dev_name = _dev['DEVNAME'].strip('/dev/')
-        devs[dev_name] = \
+                dev_name = root_dev
+                
+                
+        devs['by_name'][dev_name] = \
                 {
-                    'id_prod': _dev.get('ID_MODEL'),
+                    'id_prod': _dev.get('ID_MODEL_ID'),
+                    'id_model': _dev.get('ID_MODEL'),
+                    'id_vendorid': _dev.get('ID_VENDOR_ID'),
+                    'id_vendor': _dev.get('ID_VENDOR'),
                     'id_serial': _dev.get('ID_SERIAL_SHORT'),
                     'id_ifnum': _dev.get('ID_USB_INTERFACE_NUM'),
-                    'id_vendor': _dev.get('ID_VENDOR_ID'),
-                    'id_path': _dev.get('ID_PATH')
+                    'id_path': _dev.get('ID_PATH'),
+                    'root_dev': True if dev_name == root_dev else False
+                }
+        _ser = devs['by_name'][dev_name]['id_serial']
+        if _ser in devs['dup_ser']:
+            devs['dup_ser'][_ser]['id_paths'].append(devs['by_name'][dev_name]['id_path'])
+            devs['dup_ser'][_ser]['id_ifnums'].append(devs['by_name'][dev_name]['id_ifnum'])
+        else:
+            devs['dup_ser'][_ser] = {
+                'id_prod': devs['by_name'][dev_name]['id_prod'],
+                'id_model': devs['by_name'][dev_name]['id_model'],
+                'id_vendorid': devs['by_name'][dev_name]['id_vendorid'],
+                'id_vendor': devs['by_name'][dev_name]['id_vendor'],
+                'id_paths': [devs['by_name'][dev_name]['id_path']],
+                'id_ifnums': [devs['by_name'][dev_name]['id_ifnum']]
                 }
 
-    return devs
+    del_list = []
+    for _ser in devs['dup_ser'] :
+        if len(devs['dup_ser'][_ser]['id_paths']) == 1:
+            del_list.append(_ser)
 
+    if del_list:
+        for i in del_list:
+            del devs['dup_ser'][i]
+
+    return devs if key is None else devs['by_name'][key.strip('/dev/')]
+
+def get_serial_prompt(dev, commands=None, **kwargs):
+    dev = '/dev/' + dev if '/dev/' not in dev else dev
+    ser = serial.Serial(dev, timeout=1, **kwargs)
+
+    # before writing anything, ensure there is nothing in the buffer
+    if ser.inWaiting() > 0:
+        ser.flushInput()
+
+    # send the commands:
+    ser.write(b'\r')
+    if commands:
+        for cmd in commands:
+            ser.write(bytes(cmd, 'UTF-8'))
+    # read the response, guess a length that is more than the message
+    msg = ser.read(2048)
+    return msg.decode('UTF-8')
+
+def json_print(obj):
+    print(json.dumps(obj, indent=4, sort_keys=True))
+
+def format_eof(file):
+    cmd = 'sed -i -e :a -e {} {}'.format('\'/^\\n*$/{$d;N;};/\\n$/ba\'', file)
+    return bash_command(cmd, eval_errors=False)

--- a/src/PyConsolePi/common.py
+++ b/src/PyConsolePi/common.py
@@ -615,9 +615,9 @@ def kill_hung_session(dev):
             retry += 1
     return ppid is None
 
-def get_attached_adapters():
+def detect_adapters():
     """Detect Locally Attached Adapters.
-    
+
     Returns
     -------
     dict

--- a/src/PyConsolePi/power.py
+++ b/src/PyConsolePi/power.py
@@ -46,6 +46,7 @@ class Outlets:
         '''
         # sub to make the api call to the tasmota device
         def tasmota_req(*args, **kwargs):
+            querystring = kwargs['querystring']
             try:
                 response = requests.request("GET", url, headers=headers, params=querystring, timeout=3)
                 if response.status_code == 200:

--- a/src/PyConsolePi/power.py
+++ b/src/PyConsolePi/power.py
@@ -80,7 +80,7 @@ class Outlets:
             if command in ['ON', 'OFF', 'TOGGLE']:
                 querystring = {"cmnd":"Power {}".format(command)}
             elif command == 'CYCLE': # Power off if cycle is command, powered back on below
-                if tasmota_req(params={"cmnd":"Power"}):
+                if tasmota_req(querystring={"cmnd":"Power"}):
                     querystring = {"cmnd":"Power OFF"}
                     cycle = True
                 else:
@@ -91,11 +91,11 @@ class Outlets:
             querystring = {"cmnd":"Power"}
 
         # -- // Send Request to TASMOTA \\ --
-        r = tasmota_req(params=querystring)
+        r = tasmota_req(querystring=querystring)
         if cycle:
             if not r:
                 time.sleep(CYCLE_TIME)
-                r = tasmota_req(params={"cmnd":"Power ON"})
+                r = tasmota_req(querystring={"cmnd":"Power ON"})
             else:
                 return 'Unexpected response, port returned on state expected off'
         return r

--- a/src/PyConsolePi/power.py
+++ b/src/PyConsolePi/power.py
@@ -80,7 +80,7 @@ class Outlets:
             if command in ['ON', 'OFF', 'TOGGLE']:
                 querystring = {"cmnd":"Power {}".format(command)}
             elif command == 'CYCLE': # Power off if cycle is command, powered back on below
-                if tasmota_req(querystring={"cmnd":"Power"}):
+                if tasmota_req(params={"cmnd":"Power"}):
                     querystring = {"cmnd":"Power OFF"}
                     cycle = True
                 else:
@@ -91,11 +91,11 @@ class Outlets:
             querystring = {"cmnd":"Power"}
 
         # -- // Send Request to TASMOTA \\ --
-        r = tasmota_req(querystring=querystring)
+        r = tasmota_req(params=querystring)
         if cycle:
             if not r:
                 time.sleep(CYCLE_TIME)
-                r = tasmota_req(querystring={"cmnd":"Power ON"})
+                r = tasmota_req(params={"cmnd":"Power ON"})
             else:
                 return 'Unexpected response, port returned on state expected off'
         return r

--- a/src/autohotspotN
+++ b/src/autohotspotN
@@ -1,5 +1,5 @@
 #!/bin/bash
-#version 0.95-4-N/HS-I ConsolePi Rev 1.3
+#version 0.95-4-N/HS-I ConsolePi Rev 1.5
 
 #You may share this script on the condition a reference to RaspberryConnect.com 
 #must be included in copies or derivatives of this script. 
@@ -17,9 +17,19 @@
 #Add chkWiredState function
 # chkWiredState modifies the dnsmasq DHCP server configuration
 # So the hotspot will provide an IP with no default gateway
-# if the wired interface is down.  This is so you can connect
+# if the wired interface is down.  It also cheks the domain
+# provided to the wired interface via DHCP and provides that
+# same domain to hotspot clients.
+
+# The default-gateway bit is done so you can connect
 # in a dual nic setup and not corrupt your routing table
 # with an invalid route
+
+# Passing on the domain the the hostpot users is primarily done
+# for auto-openvpn which will not initiate a connection if the
+# ConsolePi is connected to your home network.  So it's primarily
+# for me during dev to prevent openvpn from starting while I'm testing
+# stuff i.e. ConsolePi connected to ConsolePi
 
 # Supported override variables (define the variable in ConsolePi.conf to override with different value)
 # wlan_wait_time: The amount of time the script waits for connection to an SSID before reverting to hotspot
@@ -142,7 +152,7 @@ ChkWiredState()
                      sed -i "/domain=/s/.*/${eth0_dom}/" /etc/dnsmasq.conf && 
                      use_eth_dom=true || use_eth_dom=false
                 fi
-                $use_eth_dom && echo Active Lease Found on $ethdev with domain $eth0_dom using same for HotSpot clients ||
+                $use_eth_dom && echo Active Lease Found on $ethdev with $eth0_dom using same for HotSpot clients ||
                 echo [ERROR AutoHotSpotN:ChkWiredState] Failed to Configure Domain $eth0_dom for HostSpot clients
             else
                 echo A lease was found for $ethdev but no Domain was provided Removing Domain for HotSpot clients

--- a/src/j2render.py
+++ b/src/j2render.py
@@ -27,7 +27,6 @@ parameter_dict = parse_args()
 templateLoader = jinja2.FileSystemLoader(searchpath="/etc/ConsolePi/src/j2/")
 templateEnv = jinja2.Environment(loader=templateLoader)
 template = templateEnv.get_template(sys.argv[1] + '.j2')
-# outputText = template.render(wlan_ssid='ConsolePi', wlan_psk='hpIMC!!!', wlan_country='US')
 outputText = template.render(parameter_dict)
 template.stream(parameter_dict).dump('/tmp/{}'.format(sys.argv[1]))
 


### PR DESCRIPTION
This not only adds the ability to add from the menu but also supports more use cases, i.e. pigtail adapters that present a single serial number for all pigtails, or adapters w/ no serial added ... the latter getting an alias assigned to the USB port not the adapter.