### PR TITLE
fix remote rename (still pointed to dev menu)

### DIFF
--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -655,7 +655,7 @@ class ConsolePiMenu(Rename):
                     menu_actions['c' + str(item)] = connect
                     menu_actions['c ' + str(item)] = connect
 
-                    _cmd = f'{rem_pfx} \"sudo /\etc/\ConsolePi/\src/\consolepi-menu-dev.py rn {dev}\"'  # NoQA
+                    _cmd = f'{rem_pfx} \"sudo /\etc/\ConsolePi/\src/\consolepi-menu.py rn {dev}\"'  # NoQA
                     menu_actions[str(item)] = {'cmd': _cmd,
                                                'pre_msg': f"Connecting To {host} to Rename {dev_pretty}...",
                                                'host': host}


### PR DESCRIPTION
When menu is launched on a remote to rename... it was still pointed to the temporary dev menu.