### PR TITLE
Update consolepi-startvpn

### DIFF
--- a/src/consolepi-commands/consolepi-startvpn
+++ b/src/consolepi-commands/consolepi-startvpn
@@ -6,5 +6,5 @@ ovpn_creds="/etc/openvpn/client/ovpn_credentials"
 ovpn_options="--persist-remote-ip --ping 15"
 openvpn --config ${ovpn_config} --auth-user-pass ${ovpn_creds} --log-append ${ovpn_log} ${ovpn_options} --writepid /var/run/ovpn.pid --daemon
 ' > /tmp/consolepi-tmp-exec && sudo bash /tmp/consolepi-tmp-exec && 
-openvpn started || echo Something went wrong
+echo openvpn started || echo Something went wrong
 [ -f /tmp/consolepi-tmp-exec ] && rm /tmp/consolepi-tmp-exec


### PR DESCRIPTION
Fixed an error being displayed even though the VPN connection was successful.

- Example
```
pi@raspberrypi:~ $ consolepi-startvpn 
Options error: In [CMD-LINE]:1: Error opening configuration file: started
Use --help for more information.
Something went wrong
```