### PR TITLE
Handle rare outlet error in AutoPwrOn Thread / retain scroll-back on clear

### DIFF
--- a/installer/common.sh
+++ b/installer/common.sh
@@ -64,7 +64,7 @@ consolepi_source="https://github.com/Pack3tL0ss/ConsolePi.git"
 # header reqs 144 cols to display properly
 header() {
     $silent && return 0 # No Header for silent install
-    [ -z $1 ] && clear # pass anything as an argument to prevent screen clear
+    [ -z $1 ] && clear -x # pass anything as an argument to prevent screen clear
     if [ $tty_cols -gt 144 ]; then
         echo "                                                                                                                                                ";
         echo "                                                                                                                                                ";

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -849,7 +849,7 @@ custom_post_install_script() {
 
 # -- Display Post Install Message --
 post_install_msg() {
-    clear;echo
+    clear -x ;echo
     declare -a _msg=(
             -head "${_green}Installation Complete${_norm}"
             "${_bold}Next Steps/Info${_norm}"

--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -1192,7 +1192,7 @@ class ConsolePiMenu(Rename):
             # -- Print Baud Menu --
             # menu.menu_formatting('header', text=' Select Desired Baud Rate ', do_print=True)
             if not config.debug:
-                _ = system("clear")
+                _ = system("clear -x")
             header = menu.format_header(text=' Select Desired Baud Rate ')
             print(header)
             # print('')
@@ -1243,7 +1243,7 @@ class ConsolePiMenu(Rename):
         while not valid:
             # menu.menu_formatting('header', text=' Enter Desired Data Bits ')
             if not config.debug:
-                _ = system("clear")
+                _ = system("clear -x")
             header = menu.format_header(text=' Enter Desired Data Bits ')
             print(header)
             print('\n Default 8, Current [{}], Valid range 5-8'.format(self.data_bits))
@@ -1277,7 +1277,7 @@ class ConsolePiMenu(Rename):
 
         def print_menu():
             if not config.debug:
-                _ = system("clear")
+                _ = system("clear -x")
             # menu.menu_formatting('header', text=' Select Desired Parity ')
             header = menu.format_header(text=' Select Desired Parity ')
             print(header)
@@ -1320,7 +1320,7 @@ class ConsolePiMenu(Rename):
 
         def print_menu():
             if not config.debug:
-                _ = system("clear")
+                _ = system("clear -x")
             # menu.menu_formatting('header', text=' Select Desired Flow Control ')
             header = menu.format_header(text=' Select Desired Flow Control ')
             print(header)

--- a/src/pypkg/consolepi/__init__.py
+++ b/src/pypkg/consolepi/__init__.py
@@ -17,7 +17,7 @@ LOG_FILE = '/var/log/ConsolePi/consolepi.log'
 
 
 class Response():
-    def __init__(self, ok: bool, output=None, error=None, status_code=None, state=None, do_json=False,  **kwargs):
+    def __init__(self, ok: bool, output=None, error=None, status_code=None, state=None, do_json=False, **kwargs):
         self.ok = ok
         self.text = output
         self.error = error

--- a/src/pypkg/consolepi/exec.py
+++ b/src/pypkg/consolepi/exec.py
@@ -368,7 +368,7 @@ class ConsolePiExec:
                         if menu_actions[ch].get("pre_msg"):
                             print(menu_actions[ch]["pre_msg"])
                             c = menu_actions[ch].get("cmd")
-                            if '/dev/' in c or 'telnet' in c.lower():
+                            if calling_menu != 'rename_menu' and '/dev/' in c or 'telnet' in c.lower():
                                 print(self.menu.tty)
 
                         # --// execute the command \\--

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -271,7 +271,7 @@ class MenuParts:
     def __str__(self):
         # ---- CLEAR SCREEN -----
         if not config.debug:
-            _ = system("clear")
+            _ = system("clear -x")
         else:
             print("")  # if DEBUG need this to get off the prompt line
 


### PR DESCRIPTION
Not exactly sure what state causes it, "linked" outlets are derived
from "defined" outlets, but hit TypeError on line 81 as outlet
was NoneType.  Hit it twice, (wsl -> remote) then in new menu
session to debug could not re-create.