### PR TITLE
Handle rare issue in Auto Power On

### DIFF
--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -161,7 +161,7 @@ class Config():
             'linked': by_dev,
             'dli_power': {},
             'failures': {}
-            }
+        }
 
         return outlet_data
 
@@ -214,7 +214,7 @@ class Config():
                                 user_key.chmod(0o600)
                                 log.info(f"{hosts[h]['key']} Updated from ConsolePi global .ssh key_dir to "
                                          f"{str(user_key.parent)} for use with {h}...", show=True)
-                            key_file = str(user_key)
+                        key_file = str(user_key)
                     elif utils.valid_file(hosts[h]['key']):
                         key_file = hosts[h]['key']
                     elif utils.valid_file(f"/etc/ConsolePi/.ssh/{hosts[h]['key']}"):
@@ -227,8 +227,9 @@ class Config():
                             log.info(f"{hosts[h]['key']} imported from ConsolePi global .ssh key_dir to "
                                      f"{str(user_ssh_dir)} for use with {h}...", show=True)
                             key_file = str(user_key)
-                hosts[h]['cmd'] = f"sudo -u {self.loc_user} ssh{' ' if not key_file else f' -i {key_file} '}" \
-                                  f"-t {_user_str}{hosts[h]['address'].split(':')[0]} -p {port}"
+                hosts[h]['cmd'] = (
+                    f"sudo -u {self.loc_user} ssh{' ' if not key_file else f' -i {key_file} '}" f"-t {_user_str}{hosts[h]['address'].split(':')[0]} -p {port}"
+                )
                 # hosts[h]['cmd'] = f"sudo -u {self.loc_user} ssh -t {_user_str}{hosts[h]['address'].split(':')[0]} -p {port}"
             elif hosts[h].get('method').lower() == 'telnet':
                 port = 23 if ':' not in hosts[h]['address'] else hosts[h]['address'].split(':')[1]
@@ -363,6 +364,6 @@ class Config():
                     'log_ptr': log_ptr,
                     'cmd': cmd,
                     'line': _line
-                    }
+                }
 
         return ser2net_conf

--- a/src/pypkg/consolepi/exec.py
+++ b/src/pypkg/consolepi/exec.py
@@ -76,8 +76,17 @@ class ConsolePiExec:
         # -- // Perform Auto Power On (if not already on) \\ --
         for o in outlets["linked"][pwr_key]:
             outlet = outlets["defined"].get(o.split(":")[0])
-            ports = [] if ":" not in o else json.loads(o.replace("'", '"').split(":")[1])
-            _addr = outlet["address"]
+            if outlet:
+                ports = [] if ":" not in o else json.loads(o.replace("'", '"').split(":")[1])
+                _addr = outlet["address"]
+            else:
+                log.error(
+                    f"Skipping Auto Power On {pwr_key} for {o}. Unable to pull outlet details from defined outlets.", show=True
+                )
+                log.debugv(
+                    f"Outlet Dict:\n{json.dumps(outlets)}"
+                )
+                continue
 
             # -- // DLI web power switch Auto Power On \\ --
             #
@@ -717,6 +726,7 @@ class ConsolePiExec:
                 port = f"{_type}:{_addr}"
                 port_name = _grp
                 to_state = not pwr.data["defined"][_grp]["is_on"]
+
         if _type == "dli" or _type == "tasmota" or _type == "esphome":
             host_short = utils.get_host_short(_addr)
         else:


### PR DESCRIPTION
Not exactly sure what state causes it, "linked" outlets are derived
from "defined" outlets, but hit TypeError on line 81 as outlet
was NoneType.  Hit it twice, (wsl -> remote) then in new menu
session to debug could not re-create.