### PR TITLE
fix: ValueError on 'Launching ConsolePi Serial Console Menu' #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The Cluster feature allows you to have multiple ConsolePis connected to the netw
 The Power Control Function allows you to control power to external outlets.  ConsolePi supports:
   - [digital Loggers](https://www.digital-loggers.com/index.html) Ethernet Power Switch/Web Power Switch (including older models lacking rest API).
   - External relays controlled by ConsolePi GPIO ( Like this one [Digital-Loggers IoT Relay](https://dlidirect.com/products/iot-power-relay) ).
-  - [espHome](https://esphome.io) flashed WiFi smart outlets (i.e. SonOff S31).  These are low cost outlets based on ESP8266 microcontrollers.
+  - [espHome](https://esphome.io) flashed WiFi smart outlets (i.e. SonOff S31).  These are low cost outlets based on ESP8266/ESP32 microcontrollers.
   - [Tasmota](https://blakadder.github.io/templates/) flashed WiFi smart [outlets](https://blakadder.github.io/templates/) These are also esp8266 based outlets similar to espHome.
       > espHome/Tasmota were chosen because it allows for local control without reliance on a cloud service.  So your 'kit' can include a small relatively portable smart outlet which can be programmed to connect to the ConsolePi hotspot.  Then ConsolePi can control that outlet even if an internet connection is not available.
 - If the function is enabled and outlets are defined, an option in `consolepi-menu` will be presented allowing access to a sub-menu where those outlets can be controlled (toggle power on/off, cycle).

--- a/readme_content/power.md
+++ b/readme_content/power.md
@@ -133,30 +133,34 @@ POWER:
   powerstrip1:
     address: 10.0.10.123
     type: esphome
-    relays: [relay1, relay2, relay3, relay4]
+    relays: [r2_6400_mml-sw, r2_6400_mmr-sw, another-one, and-another]
     linked_devs:
-      AP-SERU: relay1
-      Orange6: [relay2, relay3]
+      r2_6400L-sw: r2_6400_mml-sw
+      Orange6: [outlet_4, another_outlet]
 ```
-The example above highlights the following.  Outlet `cloud_lab` has the `no_all` key set to `true`, it will be excluded from any `all` operations available in the menu (`all on`, `all off`, `cycle all`).  It also highlights A multi-port power-strip, and a single port device.  With espHome there is a `relays:` key in the config where the relays are defined.  The values should match what was configured in the yaml used to compile the binary flashed to the device, for example this is a snippet from the config used to build the binary for powerstrip1 above:
+The example above highlights the following.  Outlet `cloud_lab` has the `no_all` key set to `true`, it will be excluded from any `all` operations available in the menu (`all on`, `all off`, `cycle all`).  It also highlights A multi-port power-strip, and a single port device.  With espHome there is a `relays:` key in the config where the relays are defined.  The values should match the name (with some conversion rules explained below) configured in the yaml used to compile the binary flashed to the device, for example this is a snippet from the config used to build the binary for powerstrip1 above:
 ```
 ### THIS IS NOT AN EXAMPLE FOR ConsolePi.yaml, This is an example for espHome, more details found on espHome's site
 switch:
   - platform: gpio
-    name: "Relay1"
+    name: "R2-6400 MML-sw"
     id: relay1
     icon: "mdi:power-socket-us"
     pin:
       number: GPIO13
   - platform: gpio
-    name: "Relay2"
+    name: "R2-6400 MMR-sw"
     id: relay2
     icon: "mdi:power-socket-us"
     pin:
       number: GPIO12
 ```
-Notice the `id` of the relay that controls the outlet is what is configured as `relays:` in ConsolePi.yaml.  Beyond that similar to other outlet types you can link a device with a single outlet/relay or multiple.  You can also specify the same device across multiple controlled outlets/power-strips.  "Orange6" above will lead to outlet1 as well as relay2 and 3 on powerstrip1 all being toggled ON when connecting to Orange6 via the menu.
+Notice the `name` of the relay from the esphome config is what is configured as `relays:` in ConsolePi.yaml with the following conversion rules.
 
+  - convert to all lower case
+  - replace any spaces with underscores
+
+Beyond that similar to other outlet types you can link a device with a single outlet/relay or multiple.  You can also specify the same device across multiple controlled outlets/power-strips.  `Orange6` above will lead to `outlet1` as well as `outlet_4` and `another_outlet` on powerstrip1 all being toggled ON when connecting to Orange6 via the menu.
 
 
 #### Tasmota Flashed WiFi Smart Outlets

--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -1080,8 +1080,10 @@ class ConsolePiMenu(Rename):
             menu_actions['rn'] = self.rename_menu
         foot_opts.append('refresh')
 
-        menu_actions = menu.print_menu(outer_body, header='{{cyan}}Console{{red}}Pi{{norm}} {{cyan}}Serial Menu{{norm}}',
-                                       legend={'opts': foot_opts}, subs=slines, menu_actions=menu_actions)
+        menu_actions = menu.print_menu(
+            outer_body, header='{{cyan}}Console{{red}}Pi{{norm}} {{cyan}}Serial Menu{{norm}}',
+            legend={'opts': foot_opts}, subs=slines, menu_actions=menu_actions
+        )
 
         self.cur_menu = menu
 

--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -32,6 +32,17 @@ class Actions():
         pass
 
 
+class Choice():
+    def __init__(self, prompt: str, clear=False):
+        if not clear:
+            ch = input(prompt)
+            self.lower = ch.lower()
+            self.orig = ch
+        else:
+            self.lower = ''
+            self.orig = ''
+
+
 class ConsolePiMenu(Rename):
 
     def __init__(self, bypass_remotes: bool = False, bypass_outlets: bool = False):
@@ -387,7 +398,7 @@ class ConsolePiMenu(Rename):
                     # with Halo(text='Refreshing Outlets', spinner='dots'):
                     #     outlets = self.cpiexec.outlet_update(refresh=True, upd_linked=True)
 
-    def wait_for_input(self, prompt: str = " >> ", terminate: bool = False, locs: dict = {}) -> object:
+    def wait_for_input(self, prompt: str = " >> ", terminate: bool = False, locs: dict = {}) -> Choice:
         '''Get input from user.
 
         User Can Input One of the following for special handling:
@@ -412,16 +423,6 @@ class ConsolePiMenu(Rename):
         '''
         menu = self.menu
 
-        class choice():
-            def __init__(self, clear=False):
-                if not clear:
-                    ch = input(prompt)
-                    self.lower = ch.lower()
-                    self.orig = ch
-                else:
-                    self.lower = ''
-                    self.orig = ''
-
         try:
             # if config.debug:
             #     prompt = f'pg[{menu.cur_page}] m[r:{menu.page.rows}, c:{menu.page.cols}] ' \
@@ -431,7 +432,7 @@ class ConsolePiMenu(Rename):
                          f'a[r:{self.cur_menu.tty.rows}, c:{self.cur_menu.tty.cols}]' \
                          f'{prompt}'
 
-            ch = choice()
+            ch = Choice(prompt)
 
             # -- // toggle debug \\ --
             if ch.lower == 'debug':
@@ -439,7 +440,7 @@ class ConsolePiMenu(Rename):
                 config.debug = not config.debug
                 if config.debug:
                     log.setLevel(10)  # logging.DEBUG = 10
-                ch = choice(clear=True)
+                ch = Choice(prompt, clear=True)
 
             # -- // always accept 'exit' \\ --
             elif ch.lower == 'exit':
@@ -447,7 +448,7 @@ class ConsolePiMenu(Rename):
 
             # -- // Menu Debugging Tool prints attributes/function returns \\ --
             elif '.' in ch.orig and self.print_attribute(ch.orig, locs):
-                ch = choice(clear=True)
+                ch = Choice(prompt, clear=True)
 
             menu.menu_rows = 0  # TODO REMOVE AFTER SIMPLIFIED
 
@@ -460,7 +461,7 @@ class ConsolePiMenu(Rename):
             else:
                 log.show('Operation Aborted')
                 print('')  # prevents header and prompt on same line in debug
-                return choice(clear=True)
+                return Choice(prompt, clear=True)
 
     # ------ // DLI WEB POWER SWITCH MENU \\ ------ #
     def dli_menu(self, calling_menu: str = 'power_menu'):
@@ -520,19 +521,19 @@ class ConsolePiMenu(Rename):
                         'args': ['dli', dli],
                         'kwargs': {'port': port},  # , 'desired_state': to_state},
                         'key': 'dli_pwr'
-                        }
+                    }
                     menu_actions['c' + str(index)] = {
                         'function': pwr.pwr_cycle,
                         'args': ['dli', dli],
                         'kwargs': {'port': port},
                         'key': 'dli_pwr'
-                        }
+                    }
                     menu_actions['r' + str(index)] = {
                         'function': pwr.pwr_rename,
                         'args': ['dli', dli],
                         'kwargs': {'port': port},
                         'key': 'dli_pwr'
-                        }
+                    }
                     index += 1
 
                 # add final entry for all operations
@@ -554,7 +555,7 @@ class ConsolePiMenu(Rename):
                         'args': ['dli', dli],
                         'kwargs': {'port': 'all', 'desired_state': desired_state},
                         'key': 'dli_pwr'
-                        }
+                    }
                 elif desired_state is None:
                     for s in ['on', 'off']:
                         desired_state = True if s == 'on' else False
@@ -563,7 +564,7 @@ class ConsolePiMenu(Rename):
                             'args': ['dli', dli],
                             'kwargs': {'port': 'all', 'desired_state': desired_state},
                             'key': 'dli_pwr'
-                            }
+                        }
                 mlines.append(_line)
                 index += 1
 
@@ -575,7 +576,7 @@ class ConsolePiMenu(Rename):
                         'args': ['dli', dli],
                         'kwargs': {'port': 'all'},
                         'key': 'dli_pwr'
-                        }
+                    }
                 index = start + 10
                 start += 10
 
@@ -589,8 +590,7 @@ class ConsolePiMenu(Rename):
             subhead.append('enter r + item # i.e. "r2" to rename the outlet')
 
             legend = {'opts': ['back', 'refresh']}
-            if (not calling_menu == 'power_menu' and pwr.data) and (pwr.gpio_exists or pwr.tasmota_exists or
-                                                                    pwr.linked_exists or pwr.esphome_exists):
+            if (not calling_menu == 'power_menu' and pwr.data) and (pwr.gpio_exists or pwr.tasmota_exists or pwr.linked_exists or pwr.esphome_exists):
                 menu_actions['p'] = self.power_menu
                 legend['opts'].insert(0, 'power')
                 legend['overrides'] = {'power': ['p', 'Power Control Menu (linked, GPIO, tasmota)']}
@@ -844,7 +844,7 @@ class ConsolePiMenu(Rename):
             self.do_rename_adapter(from_name)
             self.trigger_udev()
             sys.exit()
-        while choice not in ["x"]:  # == '' or menu_actions[choice] is not None:  # choice not in ['b']:
+        while choice not in ["x"]:
             if choice == 'r':
                 local.adapters = local.build_adapter_dict(refresh=True)
                 if not direct_launch:

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -174,6 +174,7 @@ class Config():
             'defined': outlet_data,
             'linked': by_dev,
             'dli_power': {},
+            'esp_power': {},
             'failures': {}
         }
 

--- a/src/pypkg/consolepi/consolepi.py
+++ b/src/pypkg/consolepi/consolepi.py
@@ -11,11 +11,10 @@ from consolepi.menu import Menu  # NoQA
 
 
 class ConsolePi():
-    def __init__(self, bypass_remotes=False):
-        # self.response = Response
-        self.menu = Menu()
+    def __init__(self, bypass_remotes: bool = False, bypass_outlets: bool = False):
+        self.menu = Menu("main_menu")
         self.local = Local()
-        if config.cfg.get('power'):
+        if not bypass_outlets and config.cfg.get('power'):
             self.pwr_init_complete = False
             self.pwr = Outlets()
         else:

--- a/src/pypkg/consolepi/exec.py
+++ b/src/pypkg/consolepi/exec.py
@@ -205,7 +205,7 @@ class ConsolePiExec:
             bool: True if threads are still running indicating a timeout
                   None indicates no threads found ~ they have finished
         """
-        start = time.time()
+        start = time.perf_counter()
         do_log = False
         found = False
         while True:
@@ -225,16 +225,16 @@ class ConsolePiExec:
                         "[{0} {1} WAIT] {0} Threads have Completed, elapsed time: {2}".format(
                             name.strip("_").upper(),
                             thread_type.upper(),
-                            time.time() - start,
+                            round(time.perf_counter() - start, 2),
                         )
                     )
                 break
-            elif time.time() - start > timeout:
+            elif time.perf_counter() - start > timeout:
                 log.error(
                     "[{0} {1} WAIT] Timeout Waiting for {0} Threads to Complete, elapsed time: {2}".format(
                         name.strip("_").upper(),
                         thread_type.upper(),
-                        time.time() - start,
+                        round(time.perf_counter() - start, 2),
                     ),
                     show=True,
                 )

--- a/src/pypkg/consolepi/local.py
+++ b/src/pypkg/consolepi/local.py
@@ -30,12 +30,15 @@ class Local():
             self.interfaces = self.get_if_info()
         _ip_w_gw = self.interfaces['_ip_w_gw']
         rem_ip = _ip_w_gw if rem_ip is None else rem_ip
-        local = {self.hostname: {
-                                'cpuserial': self.cpuserial,
-                                'adapters': self.adapters,
-                                'interfaces': self.interfaces,
-                                'rem_ip': rem_ip,
-                                'user': config.cfg.get('rem_user', 'pi')}}
+        local = {
+            self.hostname: {
+                'cpuserial': self.cpuserial,
+                'adapters': self.adapters,
+                'interfaces': self.interfaces,
+                'rem_ip': rem_ip,
+                'user': config.cfg.get('rem_user', 'pi')
+            }
+        }
         return local
 
     def detect_adapters(self, key=None):
@@ -154,15 +157,15 @@ class Local():
     def default_ser_config(self, tty_dev, tty_port=0):
         '''Return default serial parameters when no match found in ser2net'''
         return {
-                'port': tty_port,
-                'baud': self.default_baud,
-                'dbits': 8,
-                'parity': 'n',
-                'flow': 'n',
-                'sbits': 1,
-                'logfile': None,
-                'cmd': f'picocom {tty_dev} --baud {self.default_baud}'
-                }
+            'port': tty_port,
+            'baud': self.default_baud,
+            'dbits': 8,
+            'parity': 'n',
+            'flow': 'n',
+            'sbits': 1,
+            'logfile': None,
+            'cmd': f'picocom {tty_dev} --baud {self.default_baud}'
+        }
 
     def build_adapter_dict(self, refresh=False):
         '''Create final adapter dict from udev ser2net and outlet dicts.'''
@@ -207,9 +210,11 @@ class Local():
         return if_data
 
     def get_ip_list(self):
-        return [ni.ifaddresses(i).get(ni.AF_INET, {0: {}})[0].get('addr')
-                for i in ni.interfaces() if i != 'lo' and 'docker' not in i and 'ifb' not in i
-                and ni.ifaddresses(i).get(ni.AF_INET, {0: {}})[0].get('addr')]
+        return [
+            ni.ifaddresses(i).get(ni.AF_INET, {0: {}})[0].get('addr')
+            for i in ni.interfaces()
+            if i != 'lo' and 'docker' not in i and 'ifb' not in i and ni.ifaddresses(i).get(ni.AF_INET, {0: {}})[0].get('addr')
+        ]
 
 
 if __name__ == '__main__':

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -445,16 +445,13 @@ class Menu:
                     x += len(self.body_in[idx - 1])
                 self.items_in.append([y + x for y in range(len(sec))])
 
-        # if not self.menu_actions_in or refresh:
-        #     self.menu_actions_in = menu_actions
-        #     self.actions = None
         if menu_actions:
             self.menu_actions_in = menu_actions
             self.actions = None
 
         self.actions = self.menu_actions_in if not self.actions else {**self.menu_actions_in, **self.actions}
 
-        if not self.legend_in:
+        if not self.legend_in or self.legend_in != legend:
             if isinstance(legend, dict):
                 self.legend_in = legend
             elif isinstance(legend, list):
@@ -500,6 +497,10 @@ class Menu:
         prev_pages = self.pages
         if self.pages:
             self.pages = {k: [] for k in self.pages.keys() if k <= self.cur_page}
+
+        # -- // EMPTY MENU No Adapters / HOSTS / REMOTES \\ --
+        if not body:
+            return self.empty_menu()
 
         # # -- // SET STARTING ITEM # \\ --
         if not self.reverse:
@@ -722,8 +723,9 @@ class Menu:
             menu_part.update(width=self.page.cols)
 
         print(self.page)
-
         self.init_pager()
+
+        return self.menu_actions_in
 
     def calc_size(self, body: list, subs: Union[list, None],
                   format_subs: bool = False, by_tens: bool = False) -> object:
@@ -1384,12 +1386,7 @@ class Menu:
             r = legend.get("rjust")
             f = legend_options
             legend_overrides = {
-                k: [f[k][0], "{}{}".format(f[k][1], r[k].rjust(width - len(
-                                f' {f[k][0]}.{" " if len(f[k][0]) == 2 else "  "}{f[k][1]}'
-                                )
-                            ),
-                        ),
-                    ]
+                k: [f[k][0], "{}{}".format(f[k][1], r[k].rjust(width - len(f' {f[k][0]}.{" " if len(f[k][0]) == 2 else "  "}{f[k][1]}')))]
                 for k in r
                 if k in f
             }

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -3,7 +3,7 @@
 import re
 import sys
 from os import system
-from typing import Dict, List, Tuple, Union, Any
+from typing import Dict, Iterator, List, Tuple, Union, Any
 
 from consolepi import utils, log, config  # type: ignore
 
@@ -261,7 +261,7 @@ class MenuParts:
         # self._footer.update(width=self.cols)
 
     def __repr__(self):
-        name = "" if not self.name else f" {(self.name)}"
+        name = "" if not self.name else f" ({(self.name)})"
         return f"<{self.__module__}.{type(self).__name__}{name} object at {hex(id(self))}>"
 
     def __len__(self):
@@ -281,7 +281,7 @@ class MenuParts:
         log.clear()
         return "\n".join([line for p in parts for line in p.lines])
 
-    def __iter__(self, key: str = None) -> MenuSection:
+    def __iter__(self, key: str = None) -> Iterator[MenuSection]:
         # parts = [self.header, self.subhead, self.body, self.legend, self.footer]
         for p in self.parts:
             if not p or (key and p.name != key):  # or (p.name == "legend" and p.hide):
@@ -291,6 +291,7 @@ class MenuParts:
 
     def _cols(self):
         # parts = [self.header, self.subhead, self.body, self.legend, self.footer]
+        _ = "Do Nothing Break Point Line"  # TODO remove
         return max([p.cols for p in self.parts if p] or [0])
 
     def update(self):
@@ -589,6 +590,7 @@ class Menu:
                 _sub_key = 0 if not self.reverse else -1
                 if sub and sub_section[_sub_key].split()[0] != self.body_in[sec][0].split()[0]:
                     if "Local Adapters" in sub:
+                        # if self.name != "rename_menu":
                         sub = f"[CONTINUED] {sub.replace('Rename ', '')}"
                     else:
                         sub = f"[CONTINUED] {sub.split('] ')[-1].split(' @')[0].split(' on ')[-1]}"
@@ -1248,10 +1250,20 @@ class Menu:
         head_lines.append("=" * width)
         width_list += [width]
 
-        _header = MenuSection(lines=head_lines, rows=len(head_lines), cols=max(width_list), width_list=width_list, orig=orig)
-        _header.update_method = self.format_header
-        _header.update_args = (text)
-        _header.update_kwargs = {"width": width}
+        _header = MenuSection(
+            orig=orig,
+            lines=head_lines,
+            width_list=width_list,
+            rows=len(head_lines),
+            cols=max(width_list),
+            name="header",
+            update_method=self.format_header,
+            update_args=(text, ),
+            update_kwargs={"width": width},
+        )
+        # _header.update_method = self.format_header
+        # _header.update_args = (text)
+        # _header.update_kwargs = {"width": width}
         self.page.header = _header
 
         return self.page.header
@@ -1517,8 +1529,15 @@ class Menu:
 
         mlines += [bot_line]
 
-        _footer = MenuSection(lines=mlines, rows=len(mlines), cols=width, update_method=self.format_footer,
-                              update_kwargs={"width": width})
+        _footer = MenuSection(
+            lines=mlines,
+            width_list=foot_width_list,
+            rows=len(mlines),
+            cols=width,
+            update_method=self.format_footer,
+            update_kwargs={"width": width},
+            name="footer",
+        )
         self.page.footer = _footer
 
         return _footer

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -516,7 +516,7 @@ class Menu:
         addl_rows = 0
         section_slices = {}
 
-        equal_sections = True if len(set([len(section) for section in _body])) == 1 else False
+        equal_sections = True if by_tens or len(set([len(section) for section in _body])) == 1 else False
         max_section = max([len(section) + addl_rows for section in _body])
         for idx, _section in enumerate(_body):
             if subs:


### PR DESCRIPTION
regression at some point, restore logic to check for and launch `empty_menu`

Plus some flak8 formatting

This commit also adds esphome powerstrip support in power menu
If the esphome strip has multiple outlets, and not all of them are linked, or if it has 8 outlets exactly then it
will show in the dli menu.  The 8 outlet thing seems odd, but most dlis are 8 relays, and they show up in the menu regardless.