### PR TITLE
Minor Fixes

### DIFF
--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -887,6 +887,10 @@ class ConsolePiMenu(Rename):
             loc = local.adapters
             rem = remotes.data if not direct_launch else []
 
+            if (direct_launch and not loc) or (not loc and not rem):
+                print(f"{self.log_sym_2bang}  No Local Adapters Detected. Nothing to rename, exiting...")
+                return
+
             slines = []
             outer_body = []
             item = 1
@@ -923,10 +927,6 @@ class ConsolePiMenu(Rename):
             menu_actions['b'] = None
             menu_actions['r'] = None
             menu_actions['x'] = self.exit
-
-            if not loc:
-                print(f"{self.log_sym_2bang}  No Local Adapters Detected. Nothing to rename, exiting...")
-                return
 
             menu_actions = menu.print_menu(outer_body, header='Define/Rename Adapters',
                                            legend=legend, subs=slines, menu_actions=menu_actions)

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -1425,7 +1425,7 @@ class Menu:
                 legend_text.insert(0, " " + "-" * (col_1_max + col_pad + col_2_max - 1))
 
                 # if multi-paged output, and there is room on last line of legend display toggle legend options
-                if (self.actions,get("b") and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
+                if (self.actions.get("b") and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
                     _tl = " 'TL' to hide "
                     line_slice = slice(0, len(legend_text[0]) - len(_tl) - 5)
                     legend_text[0] = f'{legend_text[0][line_slice]}{_tl}{"-" * 5}'

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -1425,7 +1425,7 @@ class Menu:
                 legend_text.insert(0, " " + "-" * (col_1_max + col_pad + col_2_max - 1))
 
                 # if multi-paged output, and there is room on last line of legend display toggle legend options
-                if (self.actions.get("b") and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
+                if (self.actions and "b" in self.actions and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
                     _tl = " 'TL' to hide "
                     line_slice = slice(0, len(legend_text[0]) - len(_tl) - 5)
                     legend_text[0] = f'{legend_text[0][line_slice]}{_tl}{"-" * 5}'

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -1425,7 +1425,7 @@ class Menu:
                 legend_text.insert(0, " " + "-" * (col_1_max + col_pad + col_2_max - 1))
 
                 # if multi-paged output, and there is room on last line of legend display toggle legend options
-                if (self.actions and "b" in self.actions and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
+                if (self.actions  and "b" in self.actions and self.actions["b"] and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
                     _tl = " 'TL' to hide "
                     line_slice = slice(0, len(legend_text[0]) - len(_tl) - 5)
                     legend_text[0] = f'{legend_text[0][line_slice]}{_tl}{"-" * 5}'

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -1425,7 +1425,7 @@ class Menu:
                 legend_text.insert(0, " " + "-" * (col_1_max + col_pad + col_2_max - 1))
 
                 # if multi-paged output, and there is room on last line of legend display toggle legend options
-                if (("b" in self.actions and self.actions["b"] and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts):
+                if (self.actions,get("b") and self.actions["b"].__name__ == "pager_prev_page") or 'next' in opts:
                     _tl = " 'TL' to hide "
                     line_slice = slice(0, len(legend_text[0]) - len(_tl) - 5)
                     legend_text[0] = f'{legend_text[0][line_slice]}{_tl}{"-" * 5}'


### PR DESCRIPTION
A remote ConsolePi with no local adapters would fail to launch rename menu (you can rename remotes).

Also re-fixed rename when you changed the baud rate, which broke with the new (added paging support and option to hide the legend for more screen real-estate)