### PR TITLE
[fix] Installer settings changes

### DIFF
--- a/installer/config.sh
+++ b/installer/config.sh
@@ -377,6 +377,7 @@ collect() {
 }
 
 verify() {
+    selected_prompts=false
     header
     echo "-------------------------------------------->>PLEASE VERIFY VALUES<<--------------------------------------------"
     echo


### PR DESCRIPTION
Selecting N to Are Values Correct during validation
Would only present new prompts when a new prompts when a new prompt was
added as a result of the upgrade.

set selected_prompts=false at start of verify() ... when collect() runs
all prompts will be displayed.