### PR TITLE
handle bcrypt implemented w rust and venv change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ cloud.data
 /installer/ConsolePi_image_creator.sh
 *__pycache__*
 .idea/*
+*.swp
+
 # /cloud/*/.credentials/*  # ignored via file in that dir
 .vscode/*
 /cloud/gdrive/headless-auth/*

--- a/.static.yaml
+++ b/.static.yaml
@@ -3,7 +3,7 @@
 # Versioning = YYYY.Major.Patch/Minor
 ---
 CONSOLEPI_VER: 2022-1.0
-INSTALLER_VER: 58
+INSTALLER_VER: 59
 CFG_FILE_VER: 10
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml
 CONFIG_FILE: /etc/ConsolePi/ConsolePi.conf # For backward compat, use yaml config going forward

--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2022-1.0
+CONSOLEPI_VER: 2022-2.0
 INSTALLER_VER: 59
 CFG_FILE_VER: 10
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -434,6 +434,7 @@ do_pyvenv() {
     process="Prepare/Check Python venv"
     logit "$process - Starting"
     venv_py3ver=""
+    export DEB_PYTHON_INSTALL_LAYOUT='deb'  # see https://askubuntu.com/questions/1406304/virtualenv-installs-envs-into-local-bin-instead-of-bin
 
     # -- Check that release upgrade or manual python upgrade hasnt made the venv python ver differ from system --
     if [ -d ${consolepi_dir}venv ] && [ -x "${consolepi_dir}venv/bin/python3" ]; then

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,5 +1,5 @@
 astroid>=2.2.5
-bcrypt>=3.1.6
+bcrypt==3.2.2                  # pinned for now due to Rust requirement until pre-compiled wheel is available bcypt 4 implemented in Rust
 cachetools>=3.1.0
 certifi>=2019.3.9
 cffi>=1.9.1

--- a/src/btconnect.sh
+++ b/src/btconnect.sh
@@ -14,7 +14,7 @@ fi
 if [ ! -z "$device" ]; then
     sudo sdptool add --channel=1 SP
     echo -e ${_cyan}initiating connection...${_norm}
-    sudo -b rfcomm connect /dev/rfcomm0 ${device} 1 >>/tmp/btclient 2>&1
+    sudo -b rfcomm connect /dev/rfcomm0 ${device} >/tmp/btclient 2>&1 ;
 
     printf "waiting for connection" # && sleep 5
     out=$(cat /tmp/btclient)
@@ -24,17 +24,16 @@ if [ ! -z "$device" ]; then
         sleep 1
         out=$(cat /tmp/btclient)
         printf '.'
-        [ $i -ge 10 ] && echo -e "\ntimeout" && break
+        [ $i -ge 20 ] && echo -e "\ntimeout" && break
     done
     echo
-    cat /tmp/btclient
 
-    if [[ ! "$rf_res" =~ "t connect" ]]; then
+    if [[ ! "$out" =~ "t connect" ]]; then
         su $iam -c "picocom /dev/rfcomm0 -b 115200 2>/dev/null"
     else
-        echo $rf_res
+        echo $out
     fi
+
 fi
 
-##cat /tmp/btclient
 rm -f /tmp/btclient

--- a/src/pypkg/consolepi/menu.py
+++ b/src/pypkg/consolepi/menu.py
@@ -594,12 +594,15 @@ class Menu:
 
                 # Update sub-header for section if CONTINUED
                 _sub_key = 0 if not self.reverse else -1
-                if sub and sub_section[_sub_key].split()[0] != self.body_in[sec][0].split()[0]:
-                    if "Local Adapters" in sub:
-                        # if self.name != "rename_menu":
-                        sub = f"[CONTINUED] {sub.replace('Rename ', '')}"
-                    else:
-                        sub = f"[CONTINUED] {sub.split('] ')[-1].split(' @')[0].split(' on ')[-1]}"
+                try:
+                    if sub and sub_section[_sub_key].split()[0] != self.body_in[sec][0].split()[0]:
+                        if "Local Adapters" in sub:
+                            # if self.name != "rename_menu":
+                            sub = f"[CONTINUED] {sub.replace('Rename ', '')}"
+                        else:
+                            sub = f"[CONTINUED] {sub.split('] ')[-1].split(' @')[0].split(' on ')[-1]}"
+                except Exception as e:
+                    sub = f"{sub} <-- Exception ({e.__class__.__name__})"
 
                 # if debug enabled Add index of section to section header (sub)
                 if sub and config.debug and not sub.startswith(f"-{sec}-"):


### PR DESCRIPTION
venv change in behavior on newer python versions to install bin in venv/local/bin vs venv/bin
bcrypt 4 implemented in Rust pin requirement until wheels available or meeting tool-chain to build wheel is less problematic