### PR TITLE
v2022-4-1  Critical fix if ser2netv4 installed, but ser2netv3 conf file still exists

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2022-4.0
+CONSOLEPI_VER: 2022-4.1
 INSTALLER_VER: 62
 CFG_FILE_VER: 10
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/src/pypkg/consolepi/__init__.py
+++ b/src/pypkg/consolepi/__init__.py
@@ -16,6 +16,11 @@ except ImportError:
 LOG_FILE = '/var/log/ConsolePi/consolepi.log'
 
 
+# For working in vscode, vscode no longer provides full path
+if os.environ.get("TERM_PROGRAM"):
+    os.environ["PATH"] = f'{os.environ["PATH"]}:/usr/local/sbin:/usr/sbin'
+
+
 class Response():
     def __init__(self, ok: bool, output=None, error=None, status_code=None, state=None, do_json=False, **kwargs):
         self.ok = ok

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -284,7 +284,7 @@ class Config():
         return host_dict
 
     def get_ser2net(self):
-        return self.get_ser2netv4() if self.ser2net_ver.startswith("4") else self.get_ser2netv3()
+        return self.get_ser2netv4() if self.ser2net_file.suffix in [".yaml", ".yml"] else self.get_ser2netv3()
 
     def get_ser2netv3(self):
         '''Parse ser2net.conf to extract connection info for serial adapters


### PR DESCRIPTION
- Detect vscode and update environment (update PATH as vscode no longer provides full PATH)
- MAJOR FIX, if you have ser2netv4 installed, but still have the v3 conf file in /etc/ser2net.conf