### PR TITLE
v2023-6.0

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2023-5.2
+CONSOLEPI_VER: 2023-6.0
 INSTALLER_VER: 67
 CFG_FILE_VER: 10
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Prior Changes can be found in the - [ChangeLog](changelog.md)
   - :zap: Convert remote ConsolePi updates to async (they were already using threading)
   - :zap: Convert remote ConsolePi updates to async (they were already using threading)
   - :loud_sound: Update Spinner with the name of the remote as reachability is being check for remote ConsolePis.  Make failures persistent (spinner shows what failed and continues one line down.)
+  - The various consolepi-services that run as daemons (for remote discovery) now display a descriptive process name (i.e. when running `top` and the like) vs generically `python3`
   - :construction: (Requires manual setup for now see issue [#119](https://github.com/Pack3tL0ss/ConsolePi/issues/119))  Add ability to ssh directly to an adapter specifying adapter by name
     - i.e. `ssh -t <consolepi address> -p 2202 <device name>`
     - real example `ssh -t consolepi4 -p 2202 r1-8360-TOP` will connect to the defined udev alias `/dev/r1-8360-TOP` connected to remote ConsolePi ConsolePi4 (you could use ip vs hostname)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 # CHANGELOG
+### Sep 2022 (v2022-3.0)  **Breaking Change for silent installs**
+  - Changed cmd-line flags for `consolepi-image` and `consolepi-install`/`consolepi-upgrade`.  Use `--help` with those commands to see the changes.
+    - This is a breaking change for silent install.  If using an install.conf file refer to the new example as some varirables have changed.
+  - Re-worked `consolepi-image` script ([consolepi-image-creator.sh](installer/consolepi-image-creator.sh)) to configure consolepi as the default user on the image.
+    - This is necessary for headless installs, as there is no default pi user anymore.
+  - Updated installation script... worked-around some dependencies that required rust build environment.
+  - Various other improvements to both of the above mentioned scripts.
 ### Nov 2021 (v2021-1.5)
   - Fix: RPI.GPIO set to use 0.7.1a4+ to accommodate known issue with python3.9 (bullseye default)
   - Fix: bluetooth.service template updated for bullseye (dynamically handles both bullseye where exec path changed and prev rel)

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -630,12 +630,17 @@ missing_param(){
 
 do_safe_dir(){
     # Prevent fatal: detected dubious ownership in repository at '/etc/ConsolePi'
+    # common is not loaded yet, hence the need to define the local vars
+    local iam=${SUDO_USER:-$(who -m | awk '{ print $1 }')}
+    local tmp_log="/tmp/consolepi_install.log"
+    local final_log="/var/log/ConsolePi/install.log"
+    [ -f "$final_log" ] && local log_file=$final_log || local log_file=$tmp_log
     if ! git config --global -l | grep -q "safe.directory=/etc/ConsolePi"; then
-        logit "Adding /etc/ConsolePi as git safe.directory globally"
+        echo "$(date +"%b %d %T") [$$][INFO][Verify git safe.directory] Adding /etc/ConsolePi as git safe.directory globally" | tee -a $log_file
         git config --global --add safe.directory /etc/ConsolePi 2>>$log_file
     fi
     if ! sudo -u $iam git config --global -l | grep -q "safe.directory=/etc/ConsolePi"; then
-        logit "Adding /etc/ConsolePi as git safe.directory globally for user $iam"
+        echo "$(date +"%b %d %T") [$$][INFO][Verify git safe.directory] Adding /etc/ConsolePi as git safe.directory globally for user $iam" | tee -a $log_file
         sudo -u $iam git config --global --add safe.directory /etc/ConsolePi 2>>$log_file
     fi
 }

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -52,3 +52,6 @@ Werkzeug>=0.15.4
 # wrapt>=1.11.2
 zeroconf>=0.23.0
 rich
+setproctitle
+aiohttp
+asyncio

--- a/src/consolepi-api.py
+++ b/src/consolepi-api.py
@@ -12,14 +12,22 @@ mdns and gdrive provide discovery/sync mechanisms, the API is used
 to ensure the remote is reachable and that the data is current.
 '''
 import sys
+
+import setproctitle
+import uvicorn  # NoQA
+from rich.traceback import install
+
 sys.path.insert(0, '/etc/ConsolePi/src/pypkg')
-from consolepi import config, log  # NoQA
-from consolepi.consolepi import ConsolePi  # NoQA
+from consolepi import config, log  # type: ignore # NoQA
+from consolepi.consolepi import ConsolePi  # type: ignore # NoQA
 from fastapi import FastAPI  # NoQA
 from pydantic import BaseModel  # NoQA
 from time import time  # NoQA
 from starlette.requests import Request  # NoQA
-import uvicorn  # NoQA
+
+install(show_locals=True)
+
+setproctitle.setproctitle("consolepi-api")
 
 
 cpi = ConsolePi()

--- a/src/consolepi-commands/consolepi-convert
+++ b/src/consolepi-commands/consolepi-convert
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sudo /etc/ConsolePi/venv/bin/python3 /etc/ConsolePi/src/convert-ser2net.py "$@"

--- a/src/consolepi-commands/consolepi-editudev
+++ b/src/consolepi-commands/consolepi-editudev
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
-sudo nano /etc/udev/rules.d/10-ConsolePi.rules /etc/ser2net.conf
+[ -f /etc/ser2net.yaml ] && ser2net_file=/etc/ser2net.yaml
+[ -f /etc/ser2net.yml ] && ser2net_file=/etc/ser2net.yml
+[ -f /etc/ser2net.conf ] && ser2net_file=/etc/ser2net.conf
+
+if [ -n "$ser2net_file" ]; then
+    sudo nano /etc/udev/rules.d/10-ConsolePi.rules "$ser2net_file"
+else
+    sudo nano /etc/udev/rules.d/10-ConsolePi.rules
+    echo '!!! No ser2net file found to edit.  Run consolepi-upgrade to init ser2net config.'
+fi
+
 
 echo use consolepi-showaliases to validate udev and ser2net, check for orphans

--- a/src/consolepi-commands/consolepi-upgrade
+++ b/src/consolepi-commands/consolepi-upgrade
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-branch=$(pushd /etc/ConsolePi >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD && popd >/dev/null || echo "master")
+branch=$(pushd /etc/ConsolePi >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD 2>/dev/null && popd >/dev/null || echo "master")
 [ ! "$branch" == "master" ] && echo -e "Script updating ${branch} branch.\n  You are on a development branch."
 
 local_dev=false

--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -11,6 +11,7 @@ from pprint import pprint
 from collections import OrderedDict as od
 from typing import Union
 from halo import Halo
+import asyncio
 # from rich.console import Console
 
 # --// ConsolePi imports \\--
@@ -891,7 +892,7 @@ class ConsolePiMenu(Rename):
             if choice == 'r':
                 local.adapters = local.build_adapter_dict(refresh=True)
                 if not direct_launch:
-                    remotes.data = remotes.get_remote(data=config.remote_update())
+                    remotes.data = asyncio.run(remotes.get_remote(data=config.remote_update()))
             loc = local.adapters
             rem = remotes.data if not direct_launch else []
 
@@ -956,7 +957,7 @@ class ConsolePiMenu(Rename):
             if choice.isdigit() and int(choice) >= rem_item:
                 print('Triggering Refresh due to Remote Name Change')
                 # remotes.refresh(bypass_cloud=True)  # NoQA TODO would be more ideal just to query the remote involved in the rename and update the dict
-                remotes.data = remotes.get_remote(data=config.remote_update(), rename=True)
+                remotes.data = asyncio.run(remotes.get_remote(data=config.remote_update(), rename=True))
 
             # TODO Temp need more elegant way to handle back to main_menu
             elif menu_actions.get(choice, {}) is None and choice == "b":
@@ -973,12 +974,7 @@ class ConsolePiMenu(Rename):
         cpi = self.cpi
         remotes = cpi.remotes
         cpi.local.adapters = cpi.local.build_adapter_dict(refresh=True)
-        remotes.data = remotes.get_remote(data=config.remote_update())
-        # loc = cpi.local.adapters
-        # rem = remotes.data
-
-    # def toggle_show_legend(self):
-    #     self.menu.show_legend = not self.menu.show_legend
+        remotes.data = asyncio.run(remotes.get_remote(data=config.remote_update()))
 
     # ------ // MAIN MENU \\ ------ #
     def main_menu(self):

--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -218,7 +218,7 @@ class ConsolePiMenu(Rename):
         cpi = self.cpi
         pwr = cpi.pwr
         # menu = self.menu
-        menu = Menu()
+        menu = Menu("power_menu")
         states = self.states
         menu_actions = {
             # 'b': self.main_menu,
@@ -1164,10 +1164,10 @@ class ConsolePiMenu(Rename):
     def con_menu(self, rename: bool = False, con_dict: dict = None):
         # menu = self.cpi.menu
         menu = Menu("con_menu")
-        menu.legend_options = {
-            'back': ['b', 'Back'],
-            'x': ['x', 'Exit']
-        }
+        # menu.legend_options = {
+        #     'back': ['b', 'Back'],
+        #     'x': ['x', 'Exit']
+        # }
         menu_actions = {
             '1': self.baud_menu,
             '2': self.data_bits_menu,
@@ -1190,7 +1190,7 @@ class ConsolePiMenu(Rename):
             self.flow = con_dict['flow']
             self.sbits = con_dict['sbits']
         while True:
-            header = ' Connection Settings Menu '
+            header = 'Connection Settings Menu'
             mlines = []
             mlines.append('Baud [{}]'.format(self.baud))
             mlines.append('Data Bits [{}]'.format(self.data_bits))
@@ -1199,7 +1199,7 @@ class ConsolePiMenu(Rename):
             legend = {'opts': ['back', 'x'],
                       'overrides': {'back': ['b', 'Back {}'.format(' (Apply Changes to Files)' if rename else '')]}
                       }
-            menu.print_menu(mlines, header=header, legend=legend, menu_actions=menu_actions)
+            menu.print_menu(mlines, header=header, legend=legend, menu_actions=menu_actions, hide_legend=False)
             ch = self.wait_for_input(locs=locals()).lower
             try:
                 if ch == 'b':
@@ -1208,13 +1208,14 @@ class ConsolePiMenu(Rename):
 
             except KeyError as e:
                 if ch:
-                    log.show('Invalid selection {}, please try again.'.format(e))
+                    log.show(f'Invalid selection {e}, please try again.')
                     log.clear()
 
     # -- // BAUD MENU \\ --
     def baud_menu(self):
         # config = self.cpi.config
-        menu = self.cpi.menu
+        # menu = self.cpi.menu
+        menu = Menu("baud_menu")
         menu_actions = od([
             ('1', 300),
             ('2', 1200),
@@ -1239,6 +1240,7 @@ class ConsolePiMenu(Rename):
                 print(' {0}. {1}'.format(key, _cur_baud if _cur_baud != self.baud else '[{}]'.format(_cur_baud)))
 
             legend = menu.format_legend(legend={"opts": 'back'})
+            menu.page.legend.hide = False  # TODO make elegant this prevents "Use 'TL' to Toggle Legend from being displayed in footer given we are not giving an option in this menu"
             footer = menu.format_footer()
             print(legend)
             print(footer)
@@ -1273,7 +1275,8 @@ class ConsolePiMenu(Rename):
 
     # -- // DATA BITS MENU \\ --
     def data_bits_menu(self):
-        menu = self.cpi.menu
+        # menu = self.cpi.menu
+        menu = Menu("data_bits")
         valid = False
         while not valid:
             if not config.debug:
@@ -1283,6 +1286,7 @@ class ConsolePiMenu(Rename):
             print('\n Default 8, Current [{}], Valid range 5-8'.format(self.data_bits))
 
             legend = menu.format_legend(legend={"opts": 'back'})
+            menu.page.legend.hide = False  # TODO make elegant this prevents "Use 'TL' to Toggle Legend from being displayed in footer given we are not giving an option in this menu"
             footer = menu.format_footer()
             print(legend)
             print(footer)
@@ -1306,7 +1310,7 @@ class ConsolePiMenu(Rename):
 
     # -- // PARITY MENU \\ --
     def parity_menu(self):
-        menu = self.cpi.menu
+        menu = Menu("parity_menu")
 
         def print_menu():
             if not config.debug:
@@ -1319,6 +1323,7 @@ class ConsolePiMenu(Rename):
             print(f" 3. {'[Even]' if self.parity == 'e' else 'Even'}")
 
             legend = menu.format_legend(legend={"opts": 'back'})
+            menu.page.legend.hide = False  # TODO make elegant this prevents "Use 'TL' to Toggle Legend from being displayed in footer given we are not giving an option in this menu"
             footer = menu.format_footer()
             print(legend)
             print(footer)
@@ -1346,7 +1351,7 @@ class ConsolePiMenu(Rename):
 
     # -- // FLOW MENU \\ --
     def flow_menu(self):
-        menu = self.cpi.menu
+        menu = Menu("flow_menu")
 
         def print_menu():
             if not config.debug:
@@ -1359,6 +1364,7 @@ class ConsolePiMenu(Rename):
             print(f" 2. {'[Xon/Xoff]' if self.flow == 'x' else 'Xon/Xoff'} (software)")
             print(f" 3. {'[RTS/CTS]' if self.flow == 'h' else 'RTS/CTS'} (hardware)")
             legend = menu.format_legend(legend={"opts": 'back'})
+            menu.page.legend.hide = False  # TODO make elegant this prevents "Use 'TL' to Toggle Legend from being displayed in footer given we are not giving an option in this menu"
             footer = menu.format_footer()
             print(legend)
             print(footer)

--- a/src/convert-ser2net.py
+++ b/src/convert-ser2net.py
@@ -1,0 +1,150 @@
+#!/etc/ConsolePi/venv/bin/python3
+
+import sys
+from pathlib import Path
+import shutil
+from rich import print
+from rich.prompt import Confirm
+from datetime import datetime
+from typing import List
+
+sys.path.insert(0, '/etc/ConsolePi/src/pypkg')
+from consolepi import config  # type: ignore # NoQA
+
+DEF_V4_FILE = Path("/etc/ConsolePi/src/ser2net.yaml")
+V3_FILE = Path("/etc/ser2net.conf")
+BAK_DIR = Path("/etc/ConsolePi/bak")
+DEF_PROMPT = f"""
+[green]--------------------[/] [cyan]ser2net[/] [bright_red]v3[/] to [green3]v4[/] conversion utility [green]--------------------[/]
+This utility will parse the [cyan]ser2net[/] v3 configuration file [cyan italic]{V3_FILE.name}[/]
+and create a ConsolePi compatible ser2net v4 config [cyan italic]ser2net.yaml[/].
+
+If ser2net v4 is installed the v3 config will be moved to {BAK_DIR}.
+"""
+
+
+class Convert:
+    def __init__(self):
+        self.v4_file: Path = self.get_v4_config_name()
+
+    def __call__(self):
+        if "-y" in " ".join(sys.argv[1:]).lower() or self.confirm():
+            _ = self.check_v4_config()
+            v4_lines = self.gather_config_data()
+            if self.v4_file.exists() and self.v4_file.read_text() == v4_lines:
+                print(f'  [magenta]-[/] Process resulted in no change in {self.v4_file.name} content.  Existing v4 config left as is.')
+            else:
+                print(f'  [magenta]-[/] Writing converted config to {self.v4_file}')
+                self.v4_file.write_text(v4_lines)
+                self.backup_v3_config()
+            print()
+        else:
+            print("[bright_red]Aborted.")
+
+    def get_v4_config_name(self) -> Path:
+        new_file = Path("/etc/ser2net.yaml")
+        if not new_file.exists() and Path("/etc/ser2net.yml").exists():
+            new_file = Path("/etc/ser2net.yml")
+
+        return new_file
+
+    def check_v4_config(self) -> bool:
+        if self.v4_file.exists():
+            if "ConsolePi" not in self.v4_file.read_text().splitlines()[2]:
+                now = datetime.now()
+                _bak_file = BAK_DIR / f'{self.v4_file.name}.{now.strftime("%F_%H%M")}'
+                print(f'  [magenta]-[/] Backing up existing non ConsolePi version of [cyan]{self.v4_file}[/] to [cyan]{_bak_file}[/].')
+                shutil.move(self.v4_file, _bak_file)
+                do_ser2net = True
+                print("  [magenta]-[/] Preparing default ConsolePi ser2net v4 base config.")
+            else:
+                print(f'  [magenta]-[/] Found existing ConsolePi compatible version of [cyan]{self.v4_file}[reset].')
+                do_ser2net = False
+        else:
+            do_ser2net = True
+            print("  [magenta]-[/] Preparing default ConsolePi ser2net v4 base config.")
+
+        return do_ser2net
+
+    def backup_v3_config(self):
+        if int("".join(config.ser2net_ver.split(".")[0])) > 3:
+            if not self.v4_file.exists:
+                print(f'  [dark_orange3][blink]!![/blink] WARNING[/]: ser2net v4 Configuration ({self.v4_file}) not found.  Keeping ser2net v3 file ({V3_FILE}) in place')
+            else:
+                now = datetime.now()
+                _bak_file = BAK_DIR / f'{V3_FILE.name}.{now.strftime("%F_%H%M")}'
+                print(f"  [magenta]-[/] ser2net [cyan]v{config.ser2net_ver}[/] installed.  Backing up v3 config {V3_FILE} to {_bak_file}")
+                shutil.move(V3_FILE, _bak_file)
+        else:
+            print(f"  [magenta]-[/] ser2net [cyan]v{config.ser2net_ver}[/] installed.  Keeping v3 config {V3_FILE} in place.")
+
+    def gather_config_data(self) -> str:
+        v3_aliases = {k: v for k, v in config.ser2net_conf.items() if not k.startswith("_") and 7000 < v.get('port', 0) <= 7999}
+        if self.v4_file.exists():
+            v4_config: List[str] = self.v4_file.read_text().splitlines(keepends=True)
+            v4_config_dict = config.get_ser2netv4(self.v4_file)
+            v4_aliases = {k: v for k, v in v4_config_dict.items() if not k.startswith("_") and 7000 < v.get('port', 0) <= 7999}
+        else:
+            v4_config: List[str] = DEF_V4_FILE.read_text().splitlines(keepends=True)
+            v4_aliases = {}
+
+        v4_user_lines = [v["v4line"] for k, v in v3_aliases.items() if k not in v4_aliases.keys()]
+
+        # Gather any trace-file references from v3 config and ensure they are defined in v4 config.
+        if "trace-" in "".join(v4_user_lines):
+            trace_lines = [line.strip().split(":")[-1].strip() for line in v4_user_lines if "trace-" in line]
+            new_defs = [ref.lstrip("*") for ref in trace_lines if ref.startswith("*")]  # trace-file defs referenced in old config
+            if new_defs:
+                existing_defs, get_next_empty, insert_idx = [], False, 19
+                for idx, line in enumerate(v4_config):
+                    if "define: &" in line and "banner" not in line and "/" in line:
+                        existing_defs += [line.split("&")[-1].split()[0]]  # define: &trace3 /var/log/ser2net/trace3...
+                    elif get_next_empty:
+                        if not line.strip() or not line.strip().startswith("define:"):
+                            get_next_empty = False
+                            insert_idx = idx
+                    elif "# TRACEFILE DEFINITIONS" in line.strip():
+                        get_next_empty = True
+                    else:
+                        continue
+
+                missing_defs = [ref for ref in new_defs if ref not in existing_defs]
+                if missing_defs:
+                    missing_lines = [line for line in config.ser2net_conf.get("_v4_tracefiles", "").splitlines() for d in missing_defs if not line.startswith("#") and f'define: &{d}' in line]
+                    if missing_lines:
+                        print(f"  [magenta]-[/] Adding trace-file definition{'s' if len(missing_defs) > 1 else ''} [cyan]{'[/], [cyan]'.join(missing_defs)}[/] referenced in v3 config.")
+                        v4_config.insert(insert_idx, "\n".join(missing_lines) + "\n")
+
+        if v4_user_lines:
+            new_cnt = len([line for line in v4_user_lines if line.startswith("connection:")])
+            print(f"  [magenta]-[/] Adding {new_cnt} alias definitions converted from {config.ser2net_file}")
+            v4_config += v4_user_lines
+            if len(v3_aliases) != new_cnt:
+                print(f"  [magenta]-[/] {len(v3_aliases) - new_cnt} aliases found in ser2net v3 config were skipped as they are already defined in the existing v4 config.")
+        elif v3_aliases and v4_aliases:
+            print(f'  [dark_orange3][blink]!![/blink] WARNING[/]: All {len(v3_aliases)} alias definitions found in the ser2net v3 config were ignored as they are already defined in the existing v4 config.')
+        else:
+            print(f'  [dark_orange3][blink]!![/blink] WARNING[/]: No User defined aliases found in {V3_FILE.name}.')
+
+        return "".join(v4_config)
+
+    @staticmethod
+    def confirm(prompt: str = None) -> bool:
+        prompt = prompt or DEF_PROMPT
+        print(DEF_PROMPT)
+        choice = Confirm.ask("Proceed?")
+        print(f"[green]{'':-^77}[/]\n")
+
+        return choice
+
+
+if __name__ == "__main__":
+    if shutil.os.getuid() != 0:
+        print("[bright_red]Error:[/] Must be run as root.  Launch with [cyan]consolepi-convert[/].")
+        sys.exit(1)
+    elif not Path("/etc/ser2net.conf").exists():
+        print("[bright_red]Error:[/] No v3 config found ([cyan]/etc/ser2net.conf[/]).")
+        sys.exit(1)
+    else:
+        convert = Convert()
+        convert()

--- a/src/dhcpcd.exit-hook
+++ b/src/dhcpcd.exit-hook
@@ -136,6 +136,7 @@ check_test_mode() {
                     echo -e "Run via consolepi-pbtest [OPTIONS]\n"
                     echo -e "Options:"
                     echo -e "    'static': Test wired fallback to static flow (wired-dhcp, configure nat if wlan has valid connection)"
+                    echo -e "    'eth0|wlan0': Simulate new IP from specified interface"
                     echo -e "    --no-cloud: bypass cloud update"
                     echo -e "    --no-push: bypass PushBullet notification"
                     echo -e "    -L|--logs: Forces output of all logs for this test session after test is ran."

--- a/src/dhcpcd.exit-hook
+++ b/src/dhcpcd.exit-hook
@@ -66,10 +66,10 @@ fi
 
 
 # >> Get Configuration from config file <<
-if [[ -f "${config_builder}" ]] && "${config_builder}" > /tmp/ConsolePi.conf && . /tmp/ConsolePi.conf ; then
+if [ -f "$config_builder" ] && "${config_builder}" > /tmp/ConsolePi.conf && . /tmp/ConsolePi.conf ; then
     rm /tmp/ConsolePi.conf
     # Disable OpenVPN if ovpn config is not found
-    $ovpn_enable && [[ ! -f "${ovpn_config}" ]] && ovpn_enable=false && logit -L -t "${log_process}-ovpn"  "OpenVPN is enabled but ConsolePi.ovpn not found - disabling" "ERROR"
+    $ovpn_enable && [ ! -f "${ovpn_config}" ] && ovpn_enable=false && logit -L -t "${log_process}-ovpn"  "OpenVPN is enabled but ConsolePi.ovpn not found - disabling" "ERROR"
 else
     # Log and exit if config not found
     logit -L -t "${log_process}" "Unable to find or Parse Configuration... disabling hooks" "ERROR"  # logit overrides exit 1 default when called from hook file

--- a/src/mdns_browser.py
+++ b/src/mdns_browser.py
@@ -8,6 +8,7 @@ import time
 import sys
 from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
 import setproctitle
+import asyncio
 
 from rich.traceback import install
 install(show_locals=True)
@@ -108,7 +109,7 @@ class MDNS_Browser:
             # TODO check this don't think needed had a hung process on one of my Pis added it to be safe
             try:
                 # TODO we are setting update time here so always result in a cache update with the restart timer
-                res = cpi.remotes.api_reachable(hostname, mdns_data[hostname])
+                res = asyncio.run(cpi.remotes.api_reachable(hostname, mdns_data[hostname]))
                 update_cache = res.update
                 if not res.data.get('adapters'):
                     self.no_adapters.append(hostname)

--- a/src/mdns_register.py
+++ b/src/mdns_register.py
@@ -8,18 +8,20 @@ import pyudev
 import threading
 import struct
 import sys
-try:
-    import better_exceptions  # NoQA pylint: disable=import-error
-except ImportError:
-    pass
+import setproctitle
+
+from rich.traceback import install
+install(show_locals=True)
 
 sys.path.insert(0, '/etc/ConsolePi/src/pypkg')
-from consolepi import log, config  # NoQA
-from consolepi.consolepi import ConsolePi  # NoQA
-from consolepi.gdrive import GoogleDrive  # NoQA
+from consolepi import log, config  # type: ignore # NoQA
+from consolepi.consolepi import ConsolePi  # type: ignore # NoQA
+from consolepi.gdrive import GoogleDrive  # type: ignore # NoQA
 
 
 UPDATE_DELAY = 30
+
+setproctitle.setproctitle("consolepi-mdnsreg")
 
 
 class MDNS_Register:
@@ -129,8 +131,11 @@ class MDNS_Register:
                     info = self.build_info(squash='interfaces')
                 except (struct.error, ValueError):
                     log.critical('[MDNS REG] data is still too big for mdns')
-                    log.debug('[MDNS REG] offending interface data \n    {}'.format(
-                            json.dumps(local.interfaces, indent=4, sort_keys=True)))
+                    log.debug(
+                        '[MDNS REG] offending interface data \n    {}'.format(
+                            json.dumps(local.interfaces, indent=4, sort_keys=True)
+                        )
+                    )
 
         return info
 

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -313,7 +313,7 @@ class Config():
                 "tw": "trace-write",
                 "tb": "trace-both",
             }
-            ser2netv4_line = f'{ser2netv4_line}    {pointers[log_type]}: *{log_alias}'
+            ser2netv4_line = f'{ser2netv4_line}    {pointers[log_type]}: *{log_alias}\n'
         return ser2netv4_line
 
     def get_ser2netv3(self):
@@ -440,7 +440,7 @@ class Config():
 
         return ser2net_conf
 
-    def get_ser2netv4(self):
+    def get_ser2netv4(self, file: Path = None) -> Dict:
         """Parse ser2net.yaml (ser2net 4.x) to extract connection info for serial adapters
 
         Args:
@@ -473,7 +473,10 @@ class Config():
         #     telnet-brk-on-sync: true
         ########################################################
         ser2net_conf = {}
-        raw = self.ser2net_file.read_text()
+        if file is None and self.ser2net_file is None:
+            return ()
+
+        raw = self.ser2net_file.read_text() if not file else file.read_text()
         raw_mod = "\n".join([line if not line.startswith("connection") else f"{line.split('&')[-1]}:" for line in raw.splitlines()])
         banner = [line for line in raw.splitlines() if line.startswith("define: &banner")]
         banner = None if not banner else banner[-1].replace("define: &banner", "").lstrip()

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -122,6 +122,8 @@ class Config():
         self.cycle_time = int(ovrd.get('cycle_time', DEFAULT_CYCLE_TIME))
         self.api_port = int(ovrd.get("api_port", DEFAULT_API_PORT))
         self.hide_legend = ovrd.get("hide_legend", False)
+        # Additional override settings not needed by the python files
+        # ovpn_share:  Share VPN connection when wired_dhcp enabled with hotspot connected devices
 
     def get_outlets_from_file(self):
         '''Get outlets defined in config

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -429,19 +429,19 @@ class Config():
         ########################################################
         # --- ser2net (4.x) config lines look like this ---
         # connection: &con0096
-        # accepter: telnet(rfc2217),tcp,2000
+        #   accepter: telnet(rfc2217),tcp,2000
+        #   connector: serialdev,/dev/ttyS0,9600n81,local
         #   enable: on
         #   options:
         #     banner: *banner
         #     kickolduser: true
         #     telnet-brk-on-sync: true
-        #   connector: serialdev,
-        #             /dev/ttyS0,
-        #             9600n81,local
         ########################################################
         ser2net_conf = {}
         raw = self.ser2net_file.read_text()
         raw_mod = "\n".join([line if not line.startswith("connection") else f"{line.split('&')[-1]}:" for line in raw.splitlines()])
+        banner = [line for line in raw.splitlines() if line.startswith("define: &banner")]
+        banner = None if not banner else banner[-1].replace("define: &banner", "").lstrip()
         ser_dict = yaml.safe_load(raw_mod)
 
         for k, v in ser_dict.items():
@@ -528,7 +528,7 @@ class Config():
                 'logfile': logfile,
                 'log_ptr': log_ptr,
                 'cmd': cmd,
-                'line': json.dumps(con_dict, indent=4)
+                'line': f'{list(con_dict.keys())[0]}\n{"".join(line if "banner:" not in line else line.replace(f"banner: {banner}", "banner: *banner") for idx, line in enumerate(yaml.safe_dump(con_dict, indent=2).splitlines(keepends=True)) if idx > 0)}'
             }
 
         return ser2net_conf

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -429,7 +429,7 @@ class Config():
         ########################################################
         # --- ser2net (4.x) config lines look like this ---
         # connection: &con0096
-        # accepter: tcp,2000
+        # accepter: telnet(rfc2217),tcp,2000
         #   enable: on
         #   options:
         #     banner: *banner

--- a/src/pypkg/consolepi/consolepi.py
+++ b/src/pypkg/consolepi/consolepi.py
@@ -11,7 +11,7 @@ from consolepi.menu import Menu  # NoQA
 
 
 class ConsolePi():
-    def __init__(self, bypass_remotes: bool = False, bypass_outlets: bool = False):
+    def __init__(self, bypass_remotes: bool = False, bypass_outlets: bool = False, bypass_cloud: bool = False):
         self.menu = Menu("main_menu")
         self.local = Local()
         if not bypass_outlets and config.cfg.get('power'):
@@ -22,7 +22,7 @@ class ConsolePi():
             self.pwr = None
         self.cpiexec = ConsolePiExec(config, self.pwr, self.local, self.menu)
         if not bypass_remotes:
-            self.remotes = Remotes(self.local, self.cpiexec)
+            self.remotes = Remotes(self.local, self.cpiexec, bypass_cloud=bypass_cloud)
 
         # TODO Move to menu launch and prompt user
         # verify TELNET is installed and install if not if hosts of type TELNET are defined.

--- a/src/pypkg/consolepi/exec.py
+++ b/src/pypkg/consolepi/exec.py
@@ -341,6 +341,7 @@ class ConsolePiExec:
             os.system("clear")
 
         if not choice.lower or choice.lower in menu_actions and menu_actions[choice.lower] is None:
+            # They just hit return with no input
             (
                 self.menu.rows,
                 self.menu.cols,
@@ -630,7 +631,8 @@ class ConsolePiExec:
                             log.show("Operation Aborted by User")
                 elif menu_actions[ch].__name__ in ["power_menu", "dli_menu"]:
                     menu_actions[ch](calling_menu=calling_menu)
-                else:
+                else:  # the selection is a function / coroutine
+                    # TODO may need to add inspect.iscoroutinefunction(func) if any of the options are async
                     menu_actions[ch]()
             except KeyError as e:
                 if len(choice.orig) <= 2 or not self.exec_shell_cmd(choice.orig):

--- a/src/pypkg/consolepi/gdrive.py
+++ b/src/pypkg/consolepi/gdrive.py
@@ -39,7 +39,8 @@ class GoogleDrive:
                 result = _request.execute()
                 break
             except Exception as e:
-                log.error(('[GDRIVE]: Exception while communicating with Gdrive\n {}'.format(e)))
+                log.show(f'Exception while communicating with Gdrive: {e.__class__.__name__}', show=True)
+                log.exception(f'[GDRIVE]: Exception while communicating with Gdrive\n{e}')
             if attempt > 2:
                 log.error(('[GDRIVE]: Giving up after {} attempts'.format(attempt)))
                 break
@@ -172,7 +173,7 @@ class GoogleDrive:
                 spreadsheetId=spreadsheet_id, range='A:B')
             result = self.exec_request(request)
             log.info('[GDRIVE]: Reading from Cloud Config')
-            if result.get('values') is not None:
+            if result and result.get('values') is not None:
                 x = 1
                 for row in result.get('values'):
                     if k == row[0]:  # k is hostname row[0] is column A of current row

--- a/src/pypkg/consolepi/remotes.py
+++ b/src/pypkg/consolepi/remotes.py
@@ -87,7 +87,7 @@ class Remotes:
             res = await self.api_reachable(remotepi, this, rename=rename)
             _ = self.running_spinners.pop(self.running_spinners.index(remotepi))
             if stdin.isatty():  # restore spin text to any spinners that are still runnning
-                self.spin.stop() if res.reachable else self.spin.fail()
+                self.spin.stop() if res.reachable else self.spin.fail(f'verifying {remotepi}')
                 if self.running_spinners:
                     self.spin.start(f"verifying {self.running_spinners[-1]}")
                 else:

--- a/src/pypkg/consolepi/remotes.py
+++ b/src/pypkg/consolepi/remotes.py
@@ -148,9 +148,6 @@ class Remotes:
 
         # update local cache if any ConsolePis found UnReachable
         if self.cache_update_pending:
-            _start = time.perf_counter()
-            if stdin.isatty():
-                spin.start("Updating local cloud cache...")
             if self.pop_list:
                 for remotepi in self.pop_list:
                     if (
@@ -173,8 +170,6 @@ class Remotes:
             data = self.update_local_cloud_file(data)
             self.pop_list = []
             self.cache_update_pending = False
-            if stdin.isatty():
-                spin.succeed(f"Updating local cloud cache... Completed in {time.perf_counter() - _start:.2f}s")
 
         # TODO this is working, prob change adapters to a list of models
         # remotes = [Remote(**{"name": k, **data[k]}) for k in data]

--- a/src/pypkg/consolepi/remotes.py
+++ b/src/pypkg/consolepi/remotes.py
@@ -9,7 +9,7 @@ from log_symbols import LogSymbols as log_sym  # Enum
 from consolepi import utils, log, config, json  # type: ignore
 from aiohttp import ClientSession
 import asyncio
-from aiohttp.client_exceptions import ContentTypeError
+from aiohttp.client_exceptions import ContentTypeError, ClientConnectorError
 # from pydantic import BaseModel
 # from consolepi.gdrive import GoogleDrive  !!--> Import burried in refresh method to speed menu load times on older platforms
 
@@ -484,7 +484,7 @@ class Remotes:
                     except (json.decoder.JSONDecodeError, ContentTypeError):
                         log.error(f'[API RQST OUT] Puked on payload from {log_host} \n{await resp.text()}')
                         ret = resp.status
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, ClientConnectorError):
             log.warning(f"[API RQST OUT] Remote ConsolePi: {log_host} TimeOut when querying via API - Unreachable.")
         except Exception as e:
             log.show(f'Exception: {e.__class__.__name__}, in remotes.get_adapters_via_api() check logs')

--- a/src/pypkg/consolepi/udevrename.py
+++ b/src/pypkg/consolepi/udevrename.py
@@ -366,9 +366,10 @@ class Rename():
                     log.error(f'Rename Menu Error while attempting to cp ser2net.conf from src {error}', show=True)
                     return error  # error added to display in calling method
 
+        # FIXME we use the precense of v3 file if it exists vs the ser2net ver
         if config.ser2net_ver.startswith("4"):
             ser2net_line = f"""connection: &{to_name}
-  accepter: tcp,{next_port}
+  accepter: telnet(rfc2217),tcp,{next_port}
   enable: on
   options:
     banner: *banner

--- a/src/pypkg/consolepi/udevrename.py
+++ b/src/pypkg/consolepi/udevrename.py
@@ -361,7 +361,7 @@ class Rename():
         else:
             new_entry = True
             if utils.valid_file(config.ser2net_file):
-                ports = [a['port'] for a in config.ser2net_conf.values() if 7000 < a.get('port', 0) <= 7999]
+                ports = [v['port'] for k, v in config.ser2net_conf.items() if not k.startswith("_") and 7000 < v.get('port', 0) <= 7999]
                 next_port = 7001 if not ports else int(max(ports)) + 1
             else:
                 next_port = 7001
@@ -452,6 +452,7 @@ class Rename():
             udev_line {str} -- The properly formatted udev line being added to the file
             section_marker {str} -- Match text used to determine where to place the line
 
+
         Keyword Arguments:
             label {str} -- The rules file GOTO label used in some scenarios
                            (i.e. multi-port 1 serial) (default: {None})
@@ -459,7 +460,8 @@ class Rename():
         Returns:
             {str|None} -- Returns error string if an error occurs
         '''
-        found = ser_label_exists = get_next = update_file = False  # init
+        found = ser_label_exists = get_next = update_file = alias_found = False  # NoQA
+        # alias_name = udev_line.split("SYMLINK+=")[1].split(",")[0].replace('"', "")  # TODO WIP add log when alias is already associated with diff serial
         goto = line = cmd = ''  # init
         rules_file = self.rules_file  # if 'ttyAMA' not in udev_line else self.ttyama_rules_file  Testing 1 rules file
         if utils.valid_file(rules_file):
@@ -475,6 +477,9 @@ class Rename():
                     # No longer including SUBSYSTEM in formatted udev line, redundant given logic @ top of rules file
                     if line.replace('SUBSYSTEM=="tty", ', '').strip() == udev_line.strip():
                         return  # Line is already in file Nothing to do.
+                    # elif f'SYMLINK+="{alias_name}",' in line:
+                    #     alias_found = True  # NoQA
+                        # log.warning(f'{rules_file.split("/")[-1]} already contains an {alias_name} alias\nExisting alias {udev_line}', show=True)
                     if get_next:
                         goto = line
                         get_next = False

--- a/src/pypkg/consolepi/udevrename.py
+++ b/src/pypkg/consolepi/udevrename.py
@@ -418,6 +418,12 @@ class Rename():
                     new_connection_line = connection_line.replace(f'&{from_name}', f'\&{to_name}')  # NoQA
                     connector_line = connector_line[0]
                     new_connector_line = connector_line.replace(f"/dev/{from_name},", f"/dev/{to_name},")
+                    expected_complete_connector_line = f"  connector: serialdev,/dev/{to_name},{baud}{parity}{dbits}{sbits},local{'' if flow == 'n' else ',' + ser2net_flow[flow].lower()}"
+                    if new_connector_line != expected_complete_connector_line:
+                        if "local" in new_connector_line:
+                            new_connector_line = expected_complete_connector_line
+                        else:
+                            return f'rename requires all serial settings be on the same line i.e. {expected_complete_connector_line}.'
                     cmds = [
                         f"sudo sed -i 's|^{connection_line}$|{new_connection_line}|g'  {config.ser2net_file}",
                         f"sudo sed -i 's|^{connector_line}$|{new_connector_line}|g'  {config.ser2net_file}"

--- a/src/remote_launcher.py
+++ b/src/remote_launcher.py
@@ -9,7 +9,7 @@ try:
     import psutil
     import sys
     import subprocess
-    from time import sleep
+    import time
     sys.path.insert(0, '/etc/ConsolePi/src/pypkg')
     from consolepi import config, utils  # type: ignore # NoQA
     from consolepi.consolepi import ConsolePi  # type: ignore # NoQA
@@ -40,33 +40,57 @@ def terminate_process(pid):
         x += 1
 
 
-if __name__ == '__main__':
-    if len(sys.argv) >= 3:
-        _cmd = sys.argv[1:]
-        ppid = find_procs_by_name(sys.argv[1], sys.argv[2])
-        retry = 0
-        msg = f"\n{sys.argv[2].replace('/dev/', '')} appears to be in use (may be a previous hung session)."
-        msg += '\nDo you want to Terminate the existing session'
-        if ppid is not None and utils.user_input_bool(msg):
-            while ppid is not None and retry < 3:
-                print('Terminating Existing Session...')
-                try:
-                    terminate_process(ppid)
-                    sleep(3)
-                    ppid = find_procs_by_name(sys.argv[1], sys.argv[2])
-                except PermissionError:
-                    print('This appears to be a locally established session, if you want to kill that do it yourself')
-                    break
-                except psutil.AccessDenied:
-                    print('This appears to be a locally established session, session will not be terminated')
-                    break
-                except psutil.NoSuchProcess:
-                    ppid = find_procs_by_name(sys.argv[1], sys.argv[2])
-                retry += 1
+def check_hung_process(cmd: str, device: str) -> int:
+    ppid = find_procs_by_name(cmd, device)
+    retry = 0
+    msg = f"\n{_device.replace('/dev/', '')} appears to be in use (may be a previous hung session)."
+    msg += '\nDo you want to Terminate the existing session'
+    if ppid is not None and utils.user_input_bool(msg):
+        while ppid is not None and retry < 3:
+            print('Terminating Existing Session...')
+            try:
+                terminate_process(ppid)
+                time.sleep(3)
+                ppid = find_procs_by_name(cmd, device)
+            except PermissionError:
+                print('This appears to be a locally established session, if you want to kill that do it yourself')
+                break
+            except psutil.AccessDenied:
+                print('This appears to be a locally established session, session will not be terminated')
+                break
+            except psutil.NoSuchProcess:
+                ppid = find_procs_by_name(cmd, device)
+            retry += 1
 
-        if ppid is None:
-            # if power feature enabled and adapter linked - ensure outlet is on
-            # TODO try/except block here
-            if config.power:
-                cpi.cpiexec.exec_auto_pwron(sys.argv[2])
-            subprocess.run(_cmd)
+    return ppid
+
+
+if __name__ == '__main__':
+    # Allow user to ssh to configured port which using ForceCommand and specifying only the device they want to connect to
+    if len(sys.argv) == 2 and "picocom" not in sys.argv[1]:
+        _device = f'/dev/{sys.argv[1].replace("/dev/", "")}'
+        adapter_data = cpi.local.adapters.get(_device)
+        if not adapter_data:
+            print(f'{_device.replace("/dev/", "")} Not found on system... Refreshing local adapters.')
+            cpi.local.build_adapter_dict(refresh=True)
+            adapter_data = cpi.local.adapters.get(_device)
+
+        if adapter_data:
+            print(f'Establishing Connection to {_device.replace("/dev/", "")}...')
+            _cmd = adapter_data["config"]["cmd"].replace("{{timestamp}}", time.strftime("%F_%H.%M")).split()
+        else:
+            print(f'{_device.replace("/dev/", "")} Not found on system... Exiting.')
+            sys.exit(1)
+    # Sent from menu on remote full command is sent
+    elif len(sys.argv) >= 3:
+        _cmd = sys.argv[1:]
+        _device = f'/dev/{sys.argv[2].replace("/dev/", "")}'
+
+    ppid = check_hung_process(_cmd[0], _device)
+
+    if ppid is None:
+        # if power feature enabled and adapter linked - ensure outlet is on
+        # TODO try/except block here
+        if config.power:
+            cpi.cpiexec.exec_auto_pwron(_device)
+        subprocess.run(_cmd)

--- a/src/ser2net.yaml
+++ b/src/ser2net.yaml
@@ -12,6 +12,20 @@
 
 define: &banner \r\nser2net port \p device \d [\B] (Debian GNU/Linux)\r\n\r\n
 
+# TRACEFILE DEFINITIONS
+define: &trace0 /var/log/ser2net/trace0-\p-\d-\s\p-\M-\D-\Y_\H\i\s.\U
+define: &trace1 /var/log/ser2net/trace1\p-\M-\D-\Y_\H\i\s.\U
+define: &trace2 /var/log/ser2net/trace2\p-\M-\D-\Y_\H\i\s.\U
+define: &trace3 /var/log/ser2net/trace3\p-\M-\D-\Y_\H\i\s.\U
+
+default:
+  name: mdns
+  value: false
+
+default:
+  name: mdns-sysattrs
+  value: false
+
 # unknown devices (known devices will also use these ports first come first serve in order)
 # -- Typical USB to serial Adapters --
 connection: &ttyUSB0

--- a/src/ser2net.yaml
+++ b/src/ser2net.yaml
@@ -15,340 +15,340 @@ define: &banner \r\nser2net port \p device \d [\B] (Debian GNU/Linux)\r\n\r\n
 # unknown devices (known devices will also use these ports first come first serve in order)
 # -- Typical USB to serial Adapters --
 connection: &ttyUSB0
-  accepter: tcp,8000
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8000
   connector: serialdev,/dev/ttyUSB0,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB1
-  accepter: tcp,8001
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8001
   connector: serialdev,/dev/ttyUSB1,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB2
-  accepter: tcp,8002
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8002
   connector: serialdev,/dev/ttyUSB2,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB3
-  accepter: tcp,8003
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8003
   connector: serialdev,/dev/ttyUSB3,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB4
-  accepter: tcp,8004
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8004
   connector: serialdev,/dev/ttyUSB4,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB5
-  accepter: tcp,8005
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8005
   connector: serialdev,/dev/ttyUSB5,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB6
-  accepter: tcp,8006
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8006
   connector: serialdev,/dev/ttyUSB6,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB7
-  accepter: tcp,8007
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8007
   connector: serialdev,/dev/ttyUSB7,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB8
-  accepter: tcp,8008
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8008
   connector: serialdev,/dev/ttyUSB8,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB9
-  accepter: tcp,8009
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8009
   connector: serialdev,/dev/ttyUSB9,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB10
-  accepter: tcp,8010
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8010
   connector: serialdev,/dev/ttyUSB10,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB11
-  accepter: tcp,8011
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8011
   connector: serialdev,/dev/ttyUSB11,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB12
-  accepter: tcp,8012
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8012
   connector: serialdev,/dev/ttyUSB12,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB13
-  accepter: tcp,8013
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8013
   connector: serialdev,/dev/ttyUSB13,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB14
-  accepter: tcp,8014
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8014
   connector: serialdev,/dev/ttyUSB14,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB15
-  accepter: tcp,8015
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8015
   connector: serialdev,/dev/ttyUSB15,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB16
-  accepter: tcp,8016
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8016
   connector: serialdev,/dev/ttyUSB16,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB17
-  accepter: tcp,8017
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8017
   connector: serialdev,/dev/ttyUSB17,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB18
-  accepter: tcp,8018
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8018
   connector: serialdev,/dev/ttyUSB18,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyUSB19
-  accepter: tcp,8019
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,8019
   connector: serialdev,/dev/ttyUSB19,9600n81,local
-connection: &ttyUSB20
-  accepter: tcp,8020
   enable: on
   options:
     banner: *banner
     kickolduser: true
     telnet-brk-on-sync: true
+connection: &ttyUSB20
+  accepter: telnet(rfc2217),tcp,8020
   connector: serialdev,/dev/ttyUSB20,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 # -- Some Networking Devices with built-in USB Console Ports show up as ttyACM --
 connection: &ttyACM0
-  accepter: tcp,9000
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9000
   connector: serialdev,/dev/ttyACM0,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM1
-  accepter: tcp,9001
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9001
   connector: serialdev,/dev/ttyACM1,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM2
-  accepter: tcp,9002
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9002
   connector: serialdev,/dev/ttyACM2,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM3
-  accepter: tcp,9003
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9003
   connector: serialdev,/dev/ttyACM3,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM4
-  accepter: tcp,9004
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9004
   connector: serialdev,/dev/ttyACM4,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM5
-  accepter: tcp,9005
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9005
   connector: serialdev,/dev/ttyACM5,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM6
-  accepter: tcp,9006
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9006
   connector: serialdev,/dev/ttyACM6,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM7
-  accepter: tcp,9007
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9007
   connector: serialdev,/dev/ttyACM7,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM8
-  accepter: tcp,9008
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9008
   connector: serialdev,/dev/ttyACM8,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM9
-  accepter: tcp,9009
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9009
   connector: serialdev,/dev/ttyACM9,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM10
-  accepter: tcp,9010
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9010
   connector: serialdev,/dev/ttyACM10,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM11
-  accepter: tcp,9011
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9011
   connector: serialdev,/dev/ttyACM11,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM12
-  accepter: tcp,9012
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9012
   connector: serialdev,/dev/ttyACM12,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM13
-  accepter: tcp,9013
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9013
   connector: serialdev,/dev/ttyACM13,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM14
-  accepter: tcp,9014
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9014
   connector: serialdev,/dev/ttyACM14,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM15
-  accepter: tcp,9015
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9015
   connector: serialdev,/dev/ttyACM15,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM16
-  accepter: tcp,9016
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9016
   connector: serialdev,/dev/ttyACM16,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM17
-  accepter: tcp,9017
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9017
   connector: serialdev,/dev/ttyACM17,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM18
-  accepter: tcp,9018
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9018
   connector: serialdev,/dev/ttyACM18,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 connection: &ttyACM19
-  accepter: tcp,9019
-  enable: on
-  options:
-    banner: *banner
-    kickolduser: true
-    telnet-brk-on-sync: true
+  accepter: telnet(rfc2217),tcp,9019
   connector: serialdev,/dev/ttyACM19,9600n81,local
-connection: &ttyACM20
-  accepter: tcp,9020
   enable: on
   options:
     banner: *banner
     kickolduser: true
     telnet-brk-on-sync: true
+connection: &ttyACM20
+  accepter: telnet(rfc2217),tcp,9020
   connector: serialdev,/dev/ttyACM20,9600n81,local
+  enable: on
+  options:
+    banner: *banner
+    kickolduser: true
+    telnet-brk-on-sync: true
 # -- predictable ports based on udev rules (use consolepi-addconsole or rename option in consolepi-menu)


### PR DESCRIPTION
  - :sparkles: Add full support for ser2netv4 add/change/rename via rename(`rn`) option in the menu, and the `consolepi-addconsole`.
  - :sparkles: Add `consolepi-convert` command, which will parse an existing ser2netv3 config (`/etc/ser2net.conf`) and create/update a ser2netv4 config (`/etc/ser2net.yaml`)
  - :zap: Convert remote ConsolePi updates to async (they were already using threading)
  - :zap: Convert remote ConsolePi updates to async (they were already using threading)
  - :loud_sound: Update Spinner with the name of the remote as reachability is being check for remote ConsolePis.  Make failures persistent (spinner shows what failed and continues one line down.)
  - The various consolepi-services that run as daemons (for remote discovery) now display a descriptive process name (i.e. when running `top` and the like) vs generically `python3`
  - :construction: (Requires manual setup for now see issue [#119](https://github.com/Pack3tL0ss/ConsolePi/issues/119))  Add ability to ssh directly to an adapter specifying adapter by name
    - i.e. `ssh -t <consolepi address> -p 2202 <device name>`
    - real example `ssh -t consolepi4 -p 2202 r1-8360-TOP` will connect to the defined udev alias `/dev/r1-8360-TOP` connected to remote ConsolePi ConsolePi4 (you could use ip vs hostname)
    > The examples uses a predictable device name (`r1-8360-TOP`) vs. the default /dev/ttyUSB# Use consolepi-addconsole or the rename(`rn`) option in `consolepi-menu` to discover and apply predictable names to connected serial adapters.
    - This feature retains power-control, so if `r1-8360-TOP` has an outlet linked to it, connecting to the device will automatically verify the outlet is on, and turn it on if not.  See [Power Control Setup](readme_content/power.md#power-control-setup) for more details.
    - This is a work in progress.  The sshd config still needs to be automated but can be manually created.  Just place the following in a new file /etc/ssh/sshd_config.d/consolepi.conf and restart ssh `systemctl restart ssh`
    ```shell
    Port 22
    Port 2202
    AddressFamily any
    ListenAddress 0.0.0.0

    Match LocalPort 2202
        ForceCommand /etc/ConsolePi/src/remote_launcher.py $SSH_ORIGINAL_COMMAND
    ```
    - In future release additional flags will be passed on to picocom i.e. `ssh -t <consolepi address> -p 2202 <device name> [any flags picocom supports]`
    - :bangbang: The `-t` option is crucial, otherwise there is no tty which causes strange behavior in the terminal (tab completion via the connected device among other things break).  Will research if there is a way to attach it on the server side.