### PR TITLE
installer v68 update requirements

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -3,7 +3,7 @@
 # Versioning = YYYY.Major.Patch/Minor
 ---
 CONSOLEPI_VER: 2023-6.1
-INSTALLER_VER: 67
+INSTALLER_VER: 68
 CFG_FILE_VER: 10
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml
 CONFIG_FILE: /etc/ConsolePi/ConsolePi.conf # For backward compat, use yaml config going forward

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -55,3 +55,4 @@ rich
 setproctitle
 aiohttp
 asyncio
+pydantic>=1.10.0  # temp FastAPI isn't forcing pydantic version high enough, utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring


### PR DESCRIPTION
:bug: FastAPI isn't forcing pydantic version high enough. Utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring