### PR TITLE
v2023-6.4

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2023-6.3
+CONSOLEPI_VER: 2023-6.4
 INSTALLER_VER: 68
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/src/pypkg/consolepi/config.py
+++ b/src/pypkg/consolepi/config.py
@@ -273,7 +273,7 @@ class Config():
                         key_file = hosts[h]['key']
                     elif utils.valid_file(f"/etc/ConsolePi/.ssh/{hosts[h]['key']}"):
                         user_ssh_dir = Path(f"/home/{self.loc_user}/.ssh/")
-                        if user_ssh_dir.is_dir:
+                        if user_ssh_dir.is_dir():
                             shutil.copy(f"/etc/ConsolePi/.ssh/{hosts[h]['key']}", user_ssh_dir)
                             user_key = Path(f"{user_ssh_dir}/{hosts[h]['key']}")
                             shutil.chown(user_key, user=self.loc_user, group=self.loc_user)


### PR DESCRIPTION
:bug: fix detection of user .ssh dir used when attempting to cp custom/device specific ssh public key