### PR TITLE
v2023-6.5

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2023-6.4
+CONSOLEPI_VER: 2023-6.5
 INSTALLER_VER: 68
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/ConsolePi.yaml.example
+++ b/ConsolePi.yaml.example
@@ -3,7 +3,7 @@
 # Create a Copy of this file with the name ConsolePi.yaml (remove ".example" extension).
 ---
 CONFIG:
-  cfg_file_ver: 10 # ---- Do Not Delete or modify this line ---- #
+  cfg_file_ver: 11 # ---- Do Not Delete or modify this line ---- #
   push: true # PushBullet Notifications: true - enable, false - disable
   push_all: true # PushBullet send notifications to all devices: true - yes, false - send only to device with iden specified by push_iden
   push_api_key: "PutYourPushBulletAPIKeyHere" # PushBullet API key
@@ -12,13 +12,14 @@ CONFIG:
   vpn_check_ip: 10.0.150.1 # used to check VPN (internal) connectivity should be ip only reachable via VPN
   net_check_ip: 8.8.4.4 # used to check Internet connectivity
   local_domain: example.com # used to bypass VPN. evals domain sent via dhcp option if matches this var will not establish vpn
+  hotspot: true  # wheather to enable AutoHotSpot Feature
   wlan_ip: 10.110.0.1 # IP of ConsolePi when in hotspot mode
   wlan_ssid: ConsolePi # SSID used in hotspot mode
   wlan_psk: ConsolePiR0cks!! # psk used for hotspot SSID
   wlan_country: US # regulatory domain for hotspot SSID
   wired_dhcp: false # Run dhcp on eth interface (after trying as client)
   wired_ip: 10.30.110.1 # Fallback IP for eth interface
-  btmode: serial # Bluetooth Mode: 'serial' or 'pan'
+  btmode: serial # Bluetooth Mode: 'serial' or 'pan'  **Not implemented yet currently always serial**
   cloud: false # enable ConsolePi cloud sync for Clustering (mdns enabled either way)
   cloud_svc: gdrive # must be gdrive (all that is supported now)
   rem_user: consolepi # The user account remotes should use to access this ConsolePi

--- a/src/autohotspotN
+++ b/src/autohotspotN
@@ -157,6 +157,19 @@ mac=()
 
 ssidsmac=("${ssids[@]}" "${mac[@]}") #combines ssid and MAC for checking
 
+ip_forward_enabled() {
+    local sysctl_files=($(ls -1 /etc/sysctl.d/*.conf))
+    local sysctl_files+=(/etc/sysctl.conf)
+    local is_set=false
+    for f in ${sysctl_files[@]}; do
+        if grep -q "^net.ipv4.ip_forward\s*=\s*1" "$f"; then
+            local is_set=true
+            break
+        fi
+    done
+    $is_set && return 0 || return 1
+}
+
 get_ssid_details() {
     wlan_ip_addr=$(wpa_cli -i $wifidev status | grep ip_address | cut -d'=' -f2)
     if which iwgetid >/dev/null ; then
@@ -205,7 +218,7 @@ KillHotspot() {
     start_stop_dnsmasq stop
     iptables -D FORWARD -i "$ethdev" -o "$wifidev" -m state --state RELATED,ESTABLISHED -j ACCEPT
     iptables -D FORWARD -i "$wifidev" -o "$ethdev" -j ACCEPT
-    echo 0 > /proc/sys/net/ipv4/ip_forward
+    ! ip_forward_enabled && echo 0 > /proc/sys/net/ipv4/ip_forward
     ip addr flush dev "$wifidev"
     ip link set dev "$wifidev" up
     dhcpcd  -n "$wifidev" >/dev/null 2>&1


### PR DESCRIPTION
✨ resolves #176 retain user defined ip_forward
When system connects to SSID as client autohotspot ensures the hotspot
is disabled and removes ip_forwarding (which it enables when it turns on
hotspot).

The autohotspot script will now check all sysctl files and if ip_forward
is enabled it will leave it as is when ensuring the hotspot is shut down.