### PR TITLE
:bookmark: v2023-6.6

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2023-6.5
+CONSOLEPI_VER: 2023-6.6
 INSTALLER_VER: 68
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/src/autohotspotN
+++ b/src/autohotspotN
@@ -391,7 +391,7 @@ FindSSID
 
 #Create Hotspot or connect to valid wifi networks
 if [ "$ssidChk" != "NoSSid" ] ; then
-    echo 0 > /proc/sys/net/ipv4/ip_forward #deactivate ip forwarding
+    ! ip_forward_enabled && echo 0 > /proc/sys/net/ipv4/ip_forward #deactivate ip forwarding
     if systemctl status hostapd | grep "(running)" >/dev/null 2>&1 ; then #hotspot running and ssid in range
         KillHotspot
         logit "Hotspot Deactivated, Bringing Wifi Up"


### PR DESCRIPTION
🐛 fix feature added in :bookmark: v2023-6.5 ... leave ip_forwarding enabled
if user has it configured for other purposes. #176 