### PR TITLE
🐛 Move pinned pydantic requirement before FastAPI

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -3,7 +3,7 @@
 # Versioning = YYYY.Major.Patch/Minor
 ---
 CONSOLEPI_VER: 2023-6.6
-INSTALLER_VER: 68
+INSTALLER_VER: 69
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml
 CONFIG_FILE: /etc/ConsolePi/ConsolePi.conf # For backward compat, use yaml config going forward

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -635,11 +635,11 @@ do_safe_dir(){
     local tmp_log="/tmp/consolepi_install.log"
     local final_log="/var/log/ConsolePi/install.log"
     [ -f "$final_log" ] && local log_file=$final_log || local log_file=$tmp_log
-    if ! git config --global -l | grep -q "safe.directory=/etc/ConsolePi"; then
+    if ! git config --global -l 2>/dev/null | grep -q "safe.directory=/etc/ConsolePi"; then
         echo "$(date +"%b %d %T") [$$][INFO][Verify git safe.directory] Adding /etc/ConsolePi as git safe.directory globally" | tee -a $log_file
         git config --global --add safe.directory /etc/ConsolePi 2>>$log_file
     fi
-    if ! sudo -u $iam git config --global -l | grep -q "safe.directory=/etc/ConsolePi"; then
+    if ! sudo -u $iam git config --global -l 2>/dev/null | grep -q "safe.directory=/etc/ConsolePi"; then
         echo "$(date +"%b %d %T") [$$][INFO][Verify git safe.directory] Adding /etc/ConsolePi as git safe.directory globally for user $iam" | tee -a $log_file
         sudo -u $iam git config --global --add safe.directory /etc/ConsolePi 2>>$log_file
     fi

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -55,4 +55,7 @@ rich
 setproctitle
 aiohttp
 asyncio
-pydantic>=1.10.0  # temp FastAPI isn't forcing pydantic version high enough, utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring
+# temp force pydantic >= 1.10.0 as FastAPI isn't forcing pydantic version high enough, utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring
+# force use of pydanticv1 on buster as no wheel for buster making install of pydanticv2 a PITA
+pydantic >= 1.10.0, <= 1.10.12 ; python_version < "3.9"
+pydantic >= 1.10.0 ; python_version >= "3.9"

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -7,6 +7,9 @@ chardet>=3.0.4
 Click>=7.0
 cryptography==3.3.2             # pinned for now due to Rust requirement introduced in 3.4 https://github.com/pyca/cryptography/issues/5771 :(
 dlipower>=1.0.176
+# temp force pydantic >= 1.10.0 as FastAPI isn't forcing pydantic version high enough, utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring
+# force use of pydanticv1 as there is not a wheel for all platforms currently, installing cargo/rust and other build deps is a PITA
+pydantic >= 1.10.0, <= 1.10.12
 fastapi>=0.44.1
 # Flask>=1.0.3
 google-api-python-client>=1.7.8
@@ -55,6 +58,3 @@ rich
 setproctitle
 aiohttp
 asyncio
-# temp force pydantic >= 1.10.0 as FastAPI isn't forcing pydantic version high enough, utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring
-# force use of pydanticv1 as there is not a wheel for all platforms currently, installing cargo/rust and other build deps is a PITA
-pydantic >= 1.10.0, <= 1.10.12

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -56,6 +56,5 @@ setproctitle
 aiohttp
 asyncio
 # temp force pydantic >= 1.10.0 as FastAPI isn't forcing pydantic version high enough, utilizes MultiHostDsn introduced in 1.10.0, but FastAPI not requiring
-# force use of pydanticv1 on buster as no wheel for buster making install of pydanticv2 a PITA
-pydantic >= 1.10.0, <= 1.10.12 ; python_version < "3.9"
-pydantic >= 1.10.0 ; python_version >= "3.9"
+# force use of pydanticv1 as there is not a wheel for all platforms currently, installing cargo/rust and other build deps is a PITA
+pydantic >= 1.10.0, <= 1.10.12


### PR DESCRIPTION
Should resolve #180 pydantic was pinned to avoid this issue, but was listed after FastAPI which uses it, but doesn't pin a version, which results in the most current (pydantic v2).  pydantic v2 is built on Rust, and currently lacks a pre-built wheel for raspberry Pi.  The environment pre-reqs to build it are more cumbersome than it's worth.  The Pin for pydantic was part of a previous release, but apparently not tested on a fresh install, as it was not in the correct position in the requirements file to be effective.

⚠️ This fix has not been tested on a fresh install.  Highly confident it should resolve the issue, getting it pushed now, as the issue breaks all fresh installs.  Will test shortly.  