### PR TITLE
🔖 v2023-1.0 Installer v70

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,8 +2,8 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2023-6.6
-INSTALLER_VER: 69
+CONSOLEPI_VER: 2024-1.0
+INSTALLER_VER: 70
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml
 CONFIG_FILE: /etc/ConsolePi/ConsolePi.conf # For backward compat, use yaml config going forward

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -443,7 +443,7 @@ do_pyvenv() {
         venv_ver=$(sudo python3 -m pip show virtualenv 2>/dev/null | grep -i version | cut -d' ' -f2)
         if [ -z "$venv_ver" ]; then
             logit "python virtualenv not installed... installing"
-            sudo python3 -m pip install virtualenv 1>/dev/null 2>> $log_file &&
+            sudo apt install python3-virtualenv 1>/dev/null 2>> $log_file &&
                 logit "Success - Install virtualenv" ||
                 logit "Error - installing virtualenv" "ERROR"
         else

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -104,8 +104,11 @@ do_apt_deps() {
 
         # If it's an RPI we ensure RPi.GPIO is up to date.
         # TODO this may not be necessary with restoration of pip install RPi.GPIO below
-        [ "$is_pi" = true ] && apt upgrade -y python3-rpi.gpio >/dev/null 2> >(grep -v "^$" | grep -v "stable CLI" | tee -a $log_file) ||
-            logit "apt upgrade python3-rpi.gpio returned an error, check logs in $log_file" "WARNING"
+        ## This would check if its current
+        # apt list -u 2> >(grep -v "^$" | grep -v "stable CLI" | tee -a delme) | grep -q python3-rpi.gpio
+        #  return code = 1 means it's not in the upgrade list so it's current
+        # [ "$is_pi" = true ] && apt upgrade -y python3-rpi.gpio >/dev/null 2> >(grep -v "^$" | grep -v "stable CLI" | tee -a $log_file) ||
+        #     logit "apt upgrade python3-rpi.gpio returned an error, check logs in $log_file" "WARNING"
 
         # TODO add picocom, maybe ser2net, ensure process_cmds can accept multiple packages
 


### PR DESCRIPTION
  - Change is really only to the installer.  Change to using apt to install python3-virtualenv as pip installing into the system env is no longer allowed per PEP 668