### PR TITLE
:bookmark: installer v81 minor fix to confirmation prompt

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -3,7 +3,7 @@
 # Versioning = YYYY.Major.Patch/Minor
 ---
 CONSOLEPI_VER: 2024-3.0
-INSTALLER_VER: 80
+INSTALLER_VER: 81
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml
 CONFIG_FILE: /etc/ConsolePi/ConsolePi.conf # For backward compat, use yaml config going forward

--- a/installer/config.sh
+++ b/installer/config.sh
@@ -397,7 +397,7 @@ verify() {
         dots "Local Lab Domain" "$local_domain"
     fi
 
-    dots "Enable Automatic HotSpot ($wired_iface)" "$hotspot"
+    dots "Enable Automatic HotSpot ($wlan_iface)" "$hotspot"
     if $hotspot ; then
         dots "ConsolePi Hot Spot IP" "$wlan_ip"
         dots " *hotspot DHCP Range" "${wlan_dhcp_start} to ${wlan_dhcp_end}"


### PR DESCRIPTION
:bug: prompt for auto hotspot during install was displaying the wrong interface (would show the wired iface vs the wlan)

This had no impact on functionality, the error was limited to the prompt. 