### PR TITLE
🔖 v2024-3.5

### DIFF
--- a/.static.yaml
+++ b/.static.yaml
@@ -2,7 +2,7 @@
 # This file should not be modified.  Static variables/paths used throughout ConsolePi
 # Versioning = YYYY.Major.Patch/Minor
 ---
-CONSOLEPI_VER: 2024-3.4
+CONSOLEPI_VER: 2024-3.5
 INSTALLER_VER: 83
 CFG_FILE_VER: 11
 CONFIG_FILE_YAML: /etc/ConsolePi/ConsolePi.yaml

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -483,7 +483,7 @@ do_pyvenv() {
             logit "WARNING - pip upgrade returned error" "WARNING"
 
         logit "pip install/upgrade ConsolePi requirements - This can take some time."
-        echo -e "\n-- Output of \"pip install --upgrade -r ${consolepi_dir}installer/requirements.txt\" --\n"
+        echo -e "\n-- Output of \"pip install --no-cache-dir --prefer-binary --upgrade -r ${consolepi_dir}installer/requirements.txt\" --\n"
         # -- RPi.GPIO is done separately as it's a distutils package installed by apt, but pypi may be newer.  this is in a venv, should do no harm
         # It will also install on non rpi Linux systems (via pip).  So does no harm to install it.
         # Will not install in python global context via apt on other systems: sudo apt install python3-rpi.gpio ; as it's only in the rpi repo
@@ -498,7 +498,7 @@ do_pyvenv() {
                 logit "pip install/upgrade RPi.GPIO (separately) returned an error." "WARNING"
         fi
         # -- Update venv packages based on requirements file --
-        sudo ${consolepi_dir}venv/bin/python3 -m pip install --no-cache-dir --upgrade -r ${consolepi_dir}installer/requirements.txt 2> >(grep -v "WARNING: Retrying " | tee -a $log_file >&2) &&
+        sudo ${consolepi_dir}venv/bin/python3 -m pip install --no-cache-dir --prefer-binary --upgrade -r ${consolepi_dir}installer/requirements.txt 2> >(grep -v "WARNING: Retrying " | tee -a $log_file >&2) &&
             ( echo; logit "Success - pip install/upgrade ConsolePi requirements" ) ||
             logit "Error - pip install/upgrade ConsolePi requirements" "ERROR"
     else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "consolepi"
-version = "0.0.5"
+version = "0.0.7"
 description = 'Acts as a serial Console Server, allowing you to remotely connect to ConsolePi via Telnet/SSH/bluetooth to gain Console Access to devices connected to local or remote ConsolePis via USB to serial adapters (i.e. Switches, Routers, Access Points... anything with a serial port).'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/consolepi-commands/consolepi-status
+++ b/src/consolepi-commands/consolepi-status
@@ -59,7 +59,7 @@ show_summary() {
 show_status() {
     not_deployed=()
     for svc in "${ALL_SVCS[@]}" ; do
-        svc_found=$(systemctl list-unit-files "${svc/.service}.service" --legend=false)
+        svc_found=$(systemctl list-unit-files "${svc/.service}.service" --no-legend)
         if [ -n "$svc_found" ]; then
             echo -e "\n---------------- // STATUS OF ${_cyan}${svc}.service${_norm} \\\\\ ---------------"
             systemctl status $svc --no-pager

--- a/src/consolepi-menu.py
+++ b/src/consolepi-menu.py
@@ -853,7 +853,8 @@ class ConsolePiMenu(Rename):
                     menu_actions['c' + str(item)] = connect
                     menu_actions['c ' + str(item)] = connect
 
-                    _cmd = f'{rem_pfx} \"sudo /\etc/\ConsolePi/\src/\consolepi-menu.py rn {dev}\"'  # type: ignore # noqa
+                    _menu_file = r"\etc\ConsolePi\src\consolepi-menu.py"
+                    _cmd = f'{rem_pfx} \"sudo {_menu_file} rn {dev}\"'  # type: ignore # noqa
                     menu_actions[str(item)] = {'cmd': _cmd,
                                                'pre_msg': f"Connecting To {host} to Rename {dev_pretty}...",
                                                'host': host}

--- a/src/pypkg/consolepi/local.py
+++ b/src/pypkg/consolepi/local.py
@@ -198,7 +198,9 @@ class Local():
         if res[0] > 0:
             log.warning('Unable to get unique identifier for this pi (cpuserial)', show=True)
             return 0
-        elif not res[1]:
+        elif res[1]:
+            return res[1]
+        else:  # for non rpi use machine-id if file exists
             machine_id_file = Path("/etc/machine-id")
             if machine_id_file.exists():
                 return machine_id_file.read_text().strip()

--- a/src/pypkg/consolepi/power/dlirest.py
+++ b/src/pypkg/consolepi/power/dlirest.py
@@ -460,7 +460,7 @@ class DLI:
             retry += 1
 
         if r and r.content.decode('UTF-8').split('URL=')[1].split('"')[0] != '/index.htm':
-            log.warn('[DLI VRFY SESSION] Unable to Renew Session for {}'.format(self.fqdn))
+            log.warning('[DLI VRFY SESSION] Unable to Renew Session for {}'.format(self.fqdn))
             ret_val = 400
 
         return ret_val


### PR DESCRIPTION
 - 🩹 restore cpu serial for rpi
 - 👽️update systemctl flags in `consolepi-status` due to deprecation of previously used flag.
 - ⚡️Add `--prefer-binary` flag to pip install/upgrade so wheel is used when available (even if it's an older version)